### PR TITLE
add machine identity flag to IAM Role requests

### DIFF
--- a/iam_role.go
+++ b/iam_role.go
@@ -13,13 +13,15 @@ type IamRoleRequest struct {
 	RoleName   string `json:"roleName"`
 	RoleType   string `json:"roleType"`
 	IncDefPols int    `json:"includeDefaultPolicy"`
+	AlksAccess bool   `json:"enableAlksAccess"`
 }
 
 // IamTrustRoleRequest is used to represent a new IAM Trust Role request.
 type IamTrustRoleRequest struct {
-	RoleName string `json:"roleName"`
-	RoleType string `json:"roleType"`
-	TrustArn string `json:"trustArn"`
+	RoleName   string `json:"roleName"`
+	RoleType   string `json:"roleType"`
+	TrustArn   string `json:"trustArn"`
+	AlksAccess bool   `json:"enableAlksAccess"`
 }
 
 // IamRoleResponse is used to represent a a IAM Role.
@@ -55,10 +57,10 @@ type DeleteRoleResponse struct {
 
 // CreateIamRole will create a new IAM role on AWS. If no error is returned
 // then you will receive a IamRoleResponse object representing the new role.
-func (c *Client) CreateIamRole(roleName string, roleType string, includeDefaultPolicies bool) (*IamRoleResponse, error) {
+func (c *Client) CreateIamRole(roleName string, roleType string, includeDefaultPolicies, enableAlksAccess bool) (*IamRoleResponse, error) {
 	log.Printf("[INFO] Creating IAM role: %s", roleName)
 
-	var include int = 0
+	var include int
 	if includeDefaultPolicies {
 		include = 1
 	}
@@ -67,6 +69,7 @@ func (c *Client) CreateIamRole(roleName string, roleType string, includeDefaultP
 		roleName,
 		roleType,
 		include,
+		enableAlksAccess,
 	}
 
 	var b []byte
@@ -113,13 +116,14 @@ func (c *Client) CreateIamRole(roleName string, roleType string, includeDefaultP
 
 // CreateIamTrustRole will create a new IAM trust role on AWS. If no error is returned
 // then you will receive a IamRoleResponse object representing the new role.
-func (c *Client) CreateIamTrustRole(roleName string, roleType string, trustArn string) (*IamRoleResponse, error) {
+func (c *Client) CreateIamTrustRole(roleName string, roleType string, trustArn string, enableAlksAccess bool) (*IamRoleResponse, error) {
 	log.Printf("[INFO] Creating IAM trust role: %s", roleName)
 
 	iam := IamTrustRoleRequest{
 		roleName,
 		roleType,
 		trustArn,
+		enableAlksAccess,
 	}
 
 	var b []byte

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -7,7 +7,7 @@ import (
 func (s *S) Test_CreateIamRole(c *C) {
 	testServer.Response(202, nil, iamGetRole)
 
-	resp, err := s.client.CreateIamRole("rolebae", "Admin", false)
+	resp, err := s.client.CreateIamRole("rolebae", "Admin", false, false)
 
 	_ = testServer.WaitRequest()
 
@@ -20,7 +20,7 @@ func (s *S) Test_CreateIamRole(c *C) {
 func (s *S) Test_CreateIamTrustRole(c *C) {
 	testServer.Response(202, nil, iamGetTrustRole)
 
-	resp, err := s.client.CreateIamTrustRole("test-cross-role", "Cross Account", "arn:aws:iam::123456789123:role/test-role")
+	resp, err := s.client.CreateIamTrustRole("test-cross-role", "Cross Account", "arn:aws:iam::123456789123:role/test-role", false)
 
 	_ = testServer.WaitRequest()
 


### PR DESCRIPTION
This PR adds support for a new ALKS feature, Machine Identities by updating `create role` REST calls with the additional parameter, `enableALKSAccess`.