### PR TITLE
Support max key duration

### DIFF
--- a/api.go
+++ b/api.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 )
 
 // AlksAccount is used to represent the configuration for the ALKS client
@@ -184,18 +185,18 @@ func (c *Client) Durations() ([]int, error) {
 		return nil, err
 	}
 
-	r := new(LoginRoleResponse)
-	err := decodeBody(resp, &r)
+	lrr := new(LoginRoleResponse)
+	err = decodeBody(resp, &lrr)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing LoginRole response: %s", err)
 	}
 
-	if len(r.Errors) > 0 {
-		return nil, fmt.Errorf("Error fetching role information: %s", strings.Join(cr.Errors[:], ", "))
+	if len(lrr.Errors) > 0 {
+		return nil, fmt.Errorf("Error fetching role information: %s", strings.Join(lrr.Errors[:], ", "))
 	}
 
-	maxDuration := r.LoginRole.MaxKeyDuration
-	var durations [maxDuration]int
+	maxDuration := lrr.LoginRole.MaxKeyDuration
+	durations := make([]int, maxDuration)
 	for i := 0; i < maxDuration; i++ {
 		durations[i] = i + 1
 	}

--- a/iam_session.go
+++ b/iam_session.go
@@ -1,55 +1,14 @@
 package alks
 
 import (
-	"encoding/json"
-	"fmt"
 	"log"
 )
-
-// IamSessionRequest is used to represent a new IAM session request.
-type IamSessionRequest struct {
-	SessionTime int `json:"sessionTime"`
-}
-
-// IamSessionResponse is used to represent the session that is created.
-type IamSessionResponse struct {
-	AccessKey    string `json:"accessKey"`
-	SessionKey   string `json:"secretKey"`
-	SessionToken string `json:"sessionToken"`
-}
 
 // CreateIamSession creates a new IAM STS session. If no error is returned
 // then you will received a IamSessionResponse object containing your session
 // keys.
-func (c *Client) CreateIamSession() (*IamSessionResponse, error) {
+func (c *Client) CreateIamSession() (*SessionResponse, error) {
 	log.Println("[INFO] Creating IAM session")
 
-	iam := IamSessionRequest{1}
-	b, err := json.Marshal(struct {
-		IamSessionRequest
-		AlksAccount
-	}{iam, c.Account})
-
-	if err != nil {
-		return nil, fmt.Errorf("Error encoding IAM new session JSON: %s", err)
-	}
-
-	req, err := c.NewRequest(b, "POST", "/getIAMKeys/")
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := checkResp(c.Http.Do(req))
-	if err != nil {
-		return nil, err
-	}
-
-	ses := new(IamSessionResponse)
-	err = decodeBody(resp, &ses)
-
-	if err != nil {
-		return nil, fmt.Errorf("Error parsing create IAM session response: %s", err)
-	}
-
-	return ses, nil
+	return c.CreateSession(1, true)
 }

--- a/iam_sessions_test.go
+++ b/iam_sessions_test.go
@@ -22,7 +22,7 @@ var testServer = testutil.NewHTTPServer()
 func (s *S) SetUpSuite(c *C) {
 	testServer.Start()
 	var err error
-	s.client, err = NewClient("http://localhost:4200", "brian", "pass", "acct", "role")
+	s.client, err = NewClient("http://localhost:4200", "brian", "pass", "012345678910/ALKSAdmin - awstest123", "Admin")
 	if err != nil {
 		panic(err)
 	}
@@ -33,15 +33,17 @@ func (s *S) TearDownTest(c *C) {
 }
 
 func (s *S) Test_CreateIamSession(c *C) {
+	testServer.Response(200, nil, getIamLoginRoleResponse)
 	testServer.Response(202, nil, iamResponse)
 
 	resp, err := s.client.CreateIamSession()
 
 	_ = testServer.WaitRequest()
+	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
 	c.Assert(resp.AccessKey, Equals, "thisismykey")
-	c.Assert(resp.SessionKey, Equals, "thisismysecret")
+	c.Assert(resp.SecretKey, Equals, "thisismysecret")
 	c.Assert(resp.SessionToken, Equals, "thisismysession")
 }
 
@@ -50,5 +52,18 @@ var iamResponse = `
     "accessKey": "thisismykey",
     "secretKey": "thisismysecret",
     "sessionToken": "thisismysession"
+}
+`
+
+var getIamLoginRoleResponse = `
+{
+		"requestId": "abcd1234",
+		"statusMessage": "Success",
+		"loginRole": {
+				"account": "012345678910/ALKSAdmin",
+				"role": "Admin",
+				"iamKeyActive": true,
+				"maxKeyDuration": 36
+		}
 }
 `

--- a/session.go
+++ b/session.go
@@ -85,7 +85,12 @@ func (c *Client) CreateSession(sessionDuration int, useIAM bool) (*SessionRespon
 	log.Printf("[INFO] Creating %v hr session", sessionDuration)
 
 	var found bool = false
-	for _, v := range c.Durations() {
+	durations, err := c.Durations()
+	if err != nil {
+		return nil, fmt.Errorf("Error fetching allowable durations from ALKS: %s", err)
+	}
+
+	for _, v := range durations {
 		if sessionDuration == v {
 			found = true
 		}

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -6,10 +6,12 @@ import (
 )
 
 func (s *S) Test_CreateSession(c *C) {
+	testServer.Response(200, nil, getNonIamLoginRoleResponse)
 	testServer.Response(202, nil, sessionCreate)
 
 	resp, err := s.client.CreateSession(2, false)
 
+	_ = testServer.WaitRequest()
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
@@ -22,17 +24,23 @@ func (s *S) Test_CreateSession(c *C) {
 }
 
 func (s *S) Test_CreateSessionBadTime(c *C) {
+	testServer.Response(200, nil, getNonIamLoginRoleResponse)
+
 	resp, err := s.client.CreateSession(42, false)
+
+	_ = testServer.WaitRequest()
 
 	c.Assert(err, NotNil)
 	c.Assert(resp, IsNil)
 }
 
 func (s *S) Test_CreateSessionIam(c *C) {
+	testServer.Response(200, nil, getNonIamLoginRoleResponse)
 	testServer.Response(202, nil, sessionCreate)
 
 	resp, err := s.client.CreateSession(1, true)
 
+	_ = testServer.WaitRequest()
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
@@ -134,5 +142,18 @@ var getAccounts = `
 		}
 		]
 	}
+}
+`
+
+var getNonIamLoginRoleResponse = `
+{
+		"requestId": "abcd1234",
+		"statusMessage": "Success",
+		"loginRole": {
+				"account": "012345678910/ALKSAdmin",
+				"role": "Admin",
+				"iamKeyActive": true,
+				"maxKeyDuration": 36
+		}
 }
 `


### PR DESCRIPTION
Adds support for per-role maximum session durations by first asking ALKS for the max duration for a role before submitting a request for keys