### PR TITLE
Refactor and Error Clean Up

### DIFF
--- a/api.go
+++ b/api.go
@@ -4,47 +4,38 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-cleanhttp"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strings"
+
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
 )
 
-// AlksAccount is used to represent the configuration for the ALKS client
-type AlksAccount struct {
-	Username string `json:"userid"`
-	Password string `json:"password"`
-	Account  string `json:"account"`
-	Role     string `json:"role"`
-}
-
-type AlksSTS struct {
-	AccessKey string `json:"accessKey"`
-	SecretKey string `json:"secretKey"`
-	Token     string `json:"sessionToken"`
+// AccountDetails represents the callers Account and Role information for ALKS requests
+type AccountDetails struct {
+	Account string `json:"account,omitempty"`
+	Role    string `json:"role,omitempty"`
 }
 
 // Client represents an ALKS client and contains the account info and base url.
 type Client struct {
-	Account AlksAccount
-	STS     AlksSTS
-	BaseURL string
+	Credentials    AuthInjecter
+	AccountDetails AccountDetails
+	BaseURL        string
 
-	Http *http.Client
+	http *http.Client
 }
 
-// Represents the response from ALKS containing information about a login role
+// LoginRoleResponse represents the response from ALKS containing information about a login role
 type LoginRoleResponse struct {
-	Errors        []string  `json:"errors"`
-	StatusMessage string    `json:"statusMessage"`
-	RequestId     string    `json:"requestId"`
-	LoginRole     LoginRole `json:"loginRole"`
+	BaseResponse
+	LoginRole LoginRole `json:"loginRole"`
 }
 
-// Represents information about a login role
+// LoginRole represents information about a login role
 type LoginRole struct {
 	Account        string `json:"account"`
 	IamKeyActive   bool   `json:"iamKeyActive"`
@@ -55,16 +46,13 @@ type LoginRole struct {
 // NewClient will create a new instance of the ALKS Client. If you don't yet know the account/role
 // pass them as nil and then invoke GetAccounts().
 func NewClient(url string, username string, password string, account string, role string) (*Client, error) {
+	creds := Basic{Username: username, Password: password}
+
 	client := Client{
-		Account: AlksAccount{
-			Username: username,
-			Password: password,
-			Account:  account,
-			Role:     role,
-		},
-		STS:     AlksSTS{},
-		BaseURL: url,
-		Http:    cleanhttp.DefaultClient(),
+		Credentials:    &creds,
+		AccountDetails: AccountDetails{Account: account, Role: role},
+		BaseURL:        url,
+		http:           cleanhttp.DefaultClient(),
 	}
 
 	return &client, nil
@@ -72,21 +60,31 @@ func NewClient(url string, username string, password string, account string, rol
 
 // NewSTSClient will create a new instance of the ALKS Client using STS tokens.
 func NewSTSClient(url string, accessKey string, secretKey string, token string) (*Client, error) {
+	creds := STS{AccessKey: accessKey, SecretKey: secretKey, SessionToken: token}
 	client := Client{
-		Account: AlksAccount{},
-		STS: AlksSTS{
-			AccessKey: accessKey,
-			SecretKey: secretKey,
-			Token:     token,
-		},
-		BaseURL: url,
-		Http:    cleanhttp.DefaultClient(),
+		Credentials: &creds,
+		BaseURL:     url,
+		http:        cleanhttp.DefaultClient(),
 	}
 
 	return &client, nil
 }
 
-// newRequest will create a new request object for API requests.
+// NewBearerTokenClient will create a new instance of the ALKS Client using Okta Bearer Token auth.
+func NewBearerTokenClient(url string, bearerToken string, account string, role string) (*Client, error) {
+	creds := Bearer{Token: bearerToken}
+
+	client := Client{
+		Credentials:    &creds,
+		AccountDetails: AccountDetails{Account: account, Role: role},
+		BaseURL:        url,
+		http:           cleanhttp.DefaultClient(),
+	}
+
+	return &client, nil
+}
+
+// NewRequest will create a new request object for API requests.
 func (c *Client) NewRequest(json []byte, method string, endpoint string) (*http.Request, error) {
 	u, err := url.Parse(c.BaseURL + endpoint)
 
@@ -102,6 +100,11 @@ func (c *Client) NewRequest(json []byte, method string, endpoint string) (*http.
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "alks-go")
+	err = c.Credentials.InjectAuth(req)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error adding configuring authentication: %s", err)
+	}
 
 	log.Println("------- ALKS HTTP Request -------")
 	requestDump, err := httputil.DumpRequest(req, true)
@@ -116,50 +119,27 @@ func (c *Client) NewRequest(json []byte, method string, endpoint string) (*http.
 
 // decodeBody will convert a http.Response object to a JSON object.
 func decodeBody(resp *http.Response, out interface{}) error {
-	body, err := ioutil.ReadAll(resp.Body)
+	log.Println("------- ALKS HTTP Response -------")
+	responseDump, err := httputil.DumpResponse(resp, true)
+	if err != nil {
+		log.Println(err)
+	}
+	log.Println(string(responseDump))
+	log.Println("-------- !!!!!!!!!! ---------")
 
+	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
 
-	log.Println("------- ALKS HTTP Response -------")
-	log.Printf("Status code: %v", resp.StatusCode)
-	log.Println(string(body))
-	log.Println("-------- !!!!!!!!!! ---------")
-
 	if err = json.Unmarshal(body, &out); err != nil {
+		if resp.StatusCode >= 300 {
+			return fmt.Errorf("HTTP Status (%d): %s", resp.StatusCode, err)
+		}
 		return err
 	}
 
 	return nil
-}
-
-// checkResp will validate a http.Response based on its status code.
-func checkResp(resp *http.Response, err error) (*http.Response, error) {
-	if err != nil {
-		return resp, err
-	}
-
-	switch i := resp.StatusCode; {
-	case i == 200:
-		return resp, nil
-	case i == 201:
-		return resp, nil
-	case i == 202:
-		return resp, nil
-	case i == 204:
-		return resp, nil
-	case i == 400:
-		return nil, fmt.Errorf("API Error 400: %s", resp.Status)
-	case i == 401: // access denied will still return json
-		return resp, nil
-	case i == 402:
-		return nil, fmt.Errorf("API Error 402: %s", resp.Status)
-	case i == 422:
-		return nil, fmt.Errorf("API Error 422: %s", resp.Status)
-	default:
-		return nil, fmt.Errorf("API Error %d: %s", resp.StatusCode, resp.Status)
-	}
 }
 
 // Durations will provide the valid session durations
@@ -168,9 +148,9 @@ func (c *Client) Durations() ([]int, error) {
 
 	// Use .../me endpoint for getting durations if using STS credentials
 	var path string
-	if len(strings.TrimSpace(c.Account.Account)) > 0 {
-		accountId := c.Account.Account[0:12]
-		path = fmt.Sprintf("/loginRoles/id/%v/%v", accountId, c.Account.Role)
+	if len(strings.TrimSpace(c.AccountDetails.Account)) > 0 {
+		accountID := c.AccountDetails.Account[:12]
+		path = fmt.Sprintf("/loginRoles/id/%v/%v", accountID, c.AccountDetails.Role)
 	} else {
 		path = "/loginRoles/id/me"
 	}
@@ -180,7 +160,7 @@ func (c *Client) Durations() ([]int, error) {
 		return nil, err
 	}
 
-	resp, err := checkResp(c.Http.Do(req))
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -191,8 +171,8 @@ func (c *Client) Durations() ([]int, error) {
 		return nil, fmt.Errorf("Error parsing LoginRole response: %s", err)
 	}
 
-	if len(lrr.Errors) > 0 {
-		return nil, fmt.Errorf("Error fetching role information: %s", strings.Join(lrr.Errors[:], ", "))
+	if lrr.RequestFailed() {
+		return nil, fmt.Errorf("Error fetching role information: %s", strings.Join(lrr.GetErrors(), ", "))
 	}
 
 	maxDuration := lrr.LoginRole.MaxKeyDuration

--- a/api_test.go
+++ b/api_test.go
@@ -6,7 +6,6 @@ import (
 
 func makeClient(t *testing.T) *Client {
 	client, err := NewClient("http://foo.bar.com", "brian", "pass", "acct", "role")
-
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -15,20 +14,16 @@ func makeClient(t *testing.T) *Client {
 		t.Fatalf("base url not set on client: %s", client.BaseURL)
 	}
 
-	if client.Account.Username != "brian" {
-		t.Fatalf("account username not set on client: %s", client.Account.Username)
+	if client.Credentials == nil {
+		t.Fatalf("credentials not set on client")
 	}
 
-	if client.Account.Password != "pass" {
-		t.Fatalf("account password not set on client: %s", client.Account.Password)
+	if client.AccountDetails.Account != "acct" {
+		t.Fatalf("account account not set on client: %s", client.AccountDetails.Account)
 	}
 
-	if client.Account.Account != "acct" {
-		t.Fatalf("account account not set on client: %s", client.Account.Account)
-	}
-
-	if client.Account.Role != "role" {
-		t.Fatalf("account role not set on client: %s", client.Account.Role)
+	if client.AccountDetails.Role != "role" {
+		t.Fatalf("account role not set on client: %s", client.AccountDetails.Role)
 	}
 
 	return client
@@ -50,6 +45,10 @@ func TestClient_NewRequest(t *testing.T) {
 
 	if req.Method != "POST" {
 		t.Fatalf("bad method: %v", req.Method)
+	}
+
+	if _, _, ok := req.BasicAuth(); !ok {
+		t.Fatalf("basic auth header missing")
 	}
 }
 

--- a/credentials.go
+++ b/credentials.go
@@ -1,0 +1,79 @@
+package alks
+
+import (
+	"errors"
+	"net/http"
+)
+
+const (
+	accessKeyHeader    = "ALKS-STS-Access-Key"
+	secretKeyHeader    = "ALKS-STS-Secret-Key"
+	sessionTokenHeader = "ALKS-STS-Session-Token"
+)
+
+// Basic represents LDAP based credentials in the configuration of the ALKS client
+type Basic struct {
+	Username string `json:"-"`
+	Password string `json:"-"`
+}
+
+// STS represents AWS STS credentials in the configuration of the ALKS client
+type STS struct {
+	AccessKey    string `json:"-"`
+	SecretKey    string `json:"-"`
+	SessionToken string `json:"-"`
+}
+
+// Bearer represents an Okta bearer token in the configuration of the ALKS client
+type Bearer struct {
+	Token string `json:"-"`
+}
+
+// AuthInjecter is the interface that wraps the InjectAuth method.
+//
+// Implementations are expect to add their authentication data to request without
+// destroying existing data (if any) and should implement fallbacks when
+// possible.  Failing that, an error should be reported to the caller.
+type AuthInjecter interface {
+	InjectAuth(req *http.Request) error
+}
+
+// InjectAuth will add an Authorization header to an ALKS client request containing
+// the caller's username and password.
+func (b *Basic) InjectAuth(req *http.Request) error {
+	if _, _, ok := req.BasicAuth(); ok {
+		return errors.New("Basic Auth header already exists")
+	}
+
+	req.SetBasicAuth(b.Username, b.Password)
+
+	return nil
+}
+
+// InjectAuth will add ALKS headers to client requests containing
+// the caller's STS credentials.
+func (s *STS) InjectAuth(req *http.Request) error {
+	if req.Header.Get(accessKeyHeader) != "" &&
+		req.Header.Get(secretKeyHeader) != "" &&
+		req.Header.Get(sessionTokenHeader) != "" {
+		return errors.New("STS Auth headers already exist")
+	}
+
+	req.Header.Add(accessKeyHeader, s.AccessKey)
+	req.Header.Add(secretKeyHeader, s.SecretKey)
+	req.Header.Add(sessionTokenHeader, s.SessionToken)
+
+	return nil
+}
+
+// InjectAuth will add an authorization header to an ALKS client request containing
+// the caller's Okta bearer token.
+func (b *Bearer) InjectAuth(req *http.Request) error {
+	if req.Header.Get("Authorization") != "" {
+		return errors.New("Authorization header already exists")
+	}
+
+	req.Header.Add("Authorization", "Bearer "+b.Token)
+
+	return nil
+}

--- a/iam_role.go
+++ b/iam_role.go
@@ -26,13 +26,13 @@ type IamTrustRoleRequest struct {
 
 // IamRoleResponse is used to represent a a IAM Role.
 type IamRoleResponse struct {
-	RoleName      string   `json:"roleName"`
-	RoleType      string   `json:"roleType"`
-	RoleArn       string   `json:"roleArn"`
-	RoleIPArn     string   `json:"instanceProfileArn"`
-	RoleAddedToIP bool     `json:"addedRoleToInstanceProfile"`
-	Errors        []string `json:"errors"`
-	Exists        bool     `json:"roleExists"`
+	BaseResponse
+	RoleName      string `json:"roleName"`
+	RoleType      string `json:"roleType"`
+	RoleArn       string `json:"roleArn"`
+	RoleIPArn     string `json:"instanceProfileArn"`
+	RoleAddedToIP bool   `json:"addedRoleToInstanceProfile"`
+	Exists        bool   `json:"roleExists"`
 }
 
 // GetRoleRequest is used to represent a request for details about
@@ -50,9 +50,9 @@ type DeleteRoleRequest struct {
 // DeleteRoleResponse is used to represent the results of a IAM role
 // deletion request.
 type DeleteRoleResponse struct {
-	RoleName string   `json:"roleName"`
-	Status   string   `json:"roleArn"`
-	Errors   []string `json:"errors"`
+	BaseResponse
+	RoleName string `json:"roleName"`
+	Status   string `json:"roleArn"`
 }
 
 // CreateIamRole will create a new IAM role on AWS. If no error is returned
@@ -72,19 +72,10 @@ func (c *Client) CreateIamRole(roleName string, roleType string, includeDefaultP
 		enableAlksAccess,
 	}
 
-	var b []byte
-	var err error
-	if len(strings.TrimSpace(c.Account.Account)) > 0 {
-		b, err = json.Marshal(struct {
-			IamRoleRequest
-			AlksAccount
-		}{iam, c.Account})
-	} else {
-		b, err = json.Marshal(struct {
-			IamRoleRequest
-			AlksSTS
-		}{iam, c.STS})
-	}
+	b, err := json.Marshal(struct {
+		IamRoleRequest
+		AccountDetails
+	}{iam, c.AccountDetails})
 
 	if err != nil {
 		return nil, fmt.Errorf("Error encoding IAM create role JSON: %s", err)
@@ -95,7 +86,7 @@ func (c *Client) CreateIamRole(roleName string, roleType string, includeDefaultP
 		return nil, err
 	}
 
-	resp, err := checkResp(c.Http.Do(req))
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -107,8 +98,8 @@ func (c *Client) CreateIamRole(roleName string, roleType string, includeDefaultP
 		return nil, fmt.Errorf("Error parsing CreateRole response: %s", err)
 	}
 
-	if len(cr.Errors) > 0 {
-		return nil, fmt.Errorf("Error creating role: %s", strings.Join(cr.Errors[:], ", "))
+	if cr.RequestFailed() {
+		return nil, fmt.Errorf("Error creating role: %s", strings.Join(cr.GetErrors(), ", "))
 	}
 
 	return cr, nil
@@ -126,19 +117,10 @@ func (c *Client) CreateIamTrustRole(roleName string, roleType string, trustArn s
 		enableAlksAccess,
 	}
 
-	var b []byte
-	var err error
-	if len(strings.TrimSpace(c.Account.Account)) > 0 {
-		b, err = json.Marshal(struct {
-			IamTrustRoleRequest
-			AlksAccount
-		}{iam, c.Account})
-	} else {
-		b, err = json.Marshal(struct {
-			IamTrustRoleRequest
-			AlksSTS
-		}{iam, c.STS})
-	}
+	b, err := json.Marshal(struct {
+		IamTrustRoleRequest
+		AccountDetails
+	}{iam, c.AccountDetails})
 
 	if err != nil {
 		return nil, fmt.Errorf("Error encoding IAM create trust role JSON: %s", err)
@@ -149,7 +131,7 @@ func (c *Client) CreateIamTrustRole(roleName string, roleType string, trustArn s
 		return nil, err
 	}
 
-	resp, err := checkResp(c.Http.Do(req))
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -161,8 +143,8 @@ func (c *Client) CreateIamTrustRole(roleName string, roleType string, trustArn s
 		return nil, fmt.Errorf("Error parsing CreateTrustRole response: %s", err)
 	}
 
-	if len(cr.Errors) > 0 {
-		return nil, fmt.Errorf("Error creating trust role: %s", strings.Join(cr.Errors[:], ", "))
+	if cr.RequestFailed() {
+		return nil, fmt.Errorf("Error creating trust role: %s", strings.Join(cr.GetErrors(), ", "))
 	}
 
 	return cr, nil
@@ -175,19 +157,10 @@ func (c *Client) DeleteIamRole(id string) error {
 
 	rmRole := DeleteRoleRequest{id}
 
-	var b []byte
-	var err error
-	if len(strings.TrimSpace(c.Account.Account)) > 0 {
-		b, err = json.Marshal(struct {
-			DeleteRoleRequest
-			AlksAccount
-		}{rmRole, c.Account})
-	} else {
-		b, err = json.Marshal(struct {
-			DeleteRoleRequest
-			AlksSTS
-		}{rmRole, c.STS})
-	}
+	b, err := json.Marshal(struct {
+		DeleteRoleRequest
+		AccountDetails
+	}{rmRole, c.AccountDetails})
 
 	if err != nil {
 		return fmt.Errorf("Error encoding IAM delete role JSON: %s", err)
@@ -198,7 +171,7 @@ func (c *Client) DeleteIamRole(id string) error {
 		return err
 	}
 
-	resp, err := checkResp(c.Http.Do(req))
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return err
 	}
@@ -211,8 +184,8 @@ func (c *Client) DeleteIamRole(id string) error {
 	}
 
 	// TODO you get an error if you delete an already deleted role, need to revist for checking fail/success
-	if len(del.Errors) > 0 {
-		return fmt.Errorf("Error deleting role: %s", strings.Join(del.Errors[:], ", "))
+	if del.RequestFailed() {
+		return fmt.Errorf("Error deleting role: %s", strings.Join(del.GetErrors(), ", "))
 	}
 
 	return nil
@@ -226,19 +199,10 @@ func (c *Client) GetIamRole(roleName string) (*IamRoleResponse, error) {
 	log.Printf("[INFO] Getting IAM role: %s", roleName)
 	getRole := GetRoleRequest{roleName}
 
-	var b []byte
-	var err error
-	if len(strings.TrimSpace(c.Account.Account)) > 0 {
-		b, err = json.Marshal(struct {
-			GetRoleRequest
-			AlksAccount
-		}{getRole, c.Account})
-	} else {
-		b, err = json.Marshal(struct {
-			GetRoleRequest
-			AlksSTS
-		}{getRole, c.STS})
-	}
+	b, err := json.Marshal(struct {
+		GetRoleRequest
+		AccountDetails
+	}{getRole, c.AccountDetails})
 
 	if err != nil {
 		return nil, fmt.Errorf("Error encoding IAM create role JSON: %s", err)
@@ -249,7 +213,7 @@ func (c *Client) GetIamRole(roleName string) (*IamRoleResponse, error) {
 		return nil, err
 	}
 
-	resp, err := checkResp(c.Http.Do(req))
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -261,12 +225,12 @@ func (c *Client) GetIamRole(roleName string) (*IamRoleResponse, error) {
 		return nil, fmt.Errorf("Error parsing GetRole response: %s", err)
 	}
 
-	if len(cr.Errors) > 0 {
-		return nil, fmt.Errorf("Error getting role: %s", strings.Join(cr.Errors[:], ", "))
+	if cr.RequestFailed() {
+		return nil, fmt.Errorf("Error getting role: %s", strings.Join(cr.GetErrors(), ", "))
 	}
 
 	if !cr.Exists {
-		return nil, fmt.Errorf("Role does not exist.")
+		return nil, fmt.Errorf("role does not exist")
 	}
 
 	// This is here because ALKS returns a string representation of a Java array

--- a/response_base.go
+++ b/response_base.go
@@ -1,0 +1,29 @@
+package alks
+
+// BaseResponse represents basic fields included in all ALKS REST API responses
+type BaseResponse struct {
+	StatusMessage string   `json:"statusMessage,omitempty"`
+	Errors        []string `json:"errors,omitempty"`
+	RequestID     string   `json:"requestId,omitempty"`
+}
+
+// RequestFailed returns a boolean indicating if an ALKS response contained an error
+func (b BaseResponse) RequestFailed() bool {
+	return (b.StatusMessage != "Success" && b.StatusMessage != "") || len(b.Errors) != 0
+}
+
+// GetErrors returns a list of error messages from an ALKS response
+func (b BaseResponse) GetErrors() []string {
+	var errorMessages []string
+	for _, err := range b.Errors {
+		errorMessages = append(errorMessages, err)
+	}
+
+	if len(errorMessages) == 0 {
+		errorMessages = []string{
+			b.StatusMessage,
+		}
+	}
+
+	return errorMessages
+}

--- a/session.go
+++ b/session.go
@@ -135,11 +135,6 @@ func (c *Client) CreateSession(sessionDuration int, useIAM bool) (*SessionRespon
 		return nil, fmt.Errorf("Error parsing session create response: %s", err)
 	}
 
-	// Most API responses that are 401 include a JSON body with error messages. getKeys & getIAMKeys do not
-	if len(sr.AccessKey) == 0 {
-		return nil, fmt.Errorf("please validate username/password and account/role")
-	}
-
 	if sr.RequestFailed() {
 		return nil, fmt.Errorf("Error creating session: %s", strings.Join(sr.GetErrors(), ", "))
 	}

--- a/session.go
+++ b/session.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -14,6 +15,7 @@ type SessionRequest struct {
 
 // SessionResponse is used to represent a new STS session.
 type SessionResponse struct {
+	BaseResponse
 	AccessKey       string    `json:"accessKey"`
 	SecretKey       string    `json:"secretKey"`
 	SessionToken    string    `json:"sessionToken"`
@@ -30,8 +32,8 @@ type AccountRole struct {
 
 // AccountsResponseInt is used internally to represent a collection of ALKS accounts
 type AccountsResponseInt struct {
-	Accounts      map[string][]AccountRole `json:"accountListRole"`
-	StatusMessage string                   `json:"statusMessage"`
+	BaseResponse
+	Accounts map[string][]AccountRole `json:"accountListRole"`
 }
 
 // AccountsResponse is used to represent a collection of ALKS accounts
@@ -39,10 +41,11 @@ type AccountsResponse struct {
 	Accounts []AccountRole `json:"accountListRole"`
 }
 
+// GetAccounts return a list of AccountRoles for an AWS account
 func (c *Client) GetAccounts() (*AccountsResponse, error) {
 	log.Printf("[INFO] Requesting available accounts from ALKS")
 
-	b, err := json.Marshal(c.Account)
+	b, err := json.Marshal(c.Credentials)
 
 	if err != nil {
 		return nil, fmt.Errorf("Error encoding account request JSON: %s", err)
@@ -53,7 +56,7 @@ func (c *Client) GetAccounts() (*AccountsResponse, error) {
 		return nil, err
 	}
 
-	resp, err := checkResp(c.Http.Do(req))
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -62,11 +65,11 @@ func (c *Client) GetAccounts() (*AccountsResponse, error) {
 	err = decodeBody(resp, &_accts)
 
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing session create response: %s", err)
+		return nil, fmt.Errorf("Error parsing get accounts response: %s", err)
 	}
 
-	if _accts.StatusMessage != "Success" {
-		return nil, fmt.Errorf(_accts.StatusMessage)
+	if _accts.RequestFailed() {
+		return nil, fmt.Errorf("Error getting accounts : %s", strings.Join(_accts.GetErrors(), ", "))
 	}
 
 	accts := new(AccountsResponse)
@@ -84,7 +87,7 @@ func (c *Client) GetAccounts() (*AccountsResponse, error) {
 func (c *Client) CreateSession(sessionDuration int, useIAM bool) (*SessionResponse, error) {
 	log.Printf("[INFO] Creating %v hr session", sessionDuration)
 
-	var found bool = false
+	var found = false
 	durations, err := c.Durations()
 	if err != nil {
 		return nil, fmt.Errorf("Error fetching allowable durations from ALKS: %s", err)
@@ -104,14 +107,14 @@ func (c *Client) CreateSession(sessionDuration int, useIAM bool) (*SessionRespon
 
 	b, err := json.Marshal(struct {
 		SessionRequest
-		AlksAccount
-	}{session, c.Account})
+		AccountDetails
+	}{session, c.AccountDetails})
 
 	if err != nil {
 		return nil, fmt.Errorf("Error encoding session create JSON: %s", err)
 	}
 
-	var endpoint string = "/getKeys/"
+	var endpoint = "/getKeys/"
 	if useIAM {
 		endpoint = "/getIAMKeys/"
 	}
@@ -120,7 +123,7 @@ func (c *Client) CreateSession(sessionDuration int, useIAM bool) (*SessionRespon
 		return nil, err
 	}
 
-	resp, httpErr := checkResp(c.Http.Do(req))
+	resp, httpErr := c.http.Do(req)
 	if httpErr != nil {
 		return nil, err
 	}
@@ -134,7 +137,11 @@ func (c *Client) CreateSession(sessionDuration int, useIAM bool) (*SessionRespon
 
 	// Most API responses that are 401 include a JSON body with error messages. getKeys & getIAMKeys do not
 	if len(sr.AccessKey) == 0 {
-		return nil, fmt.Errorf("Please validate username/password and account/role.")
+		return nil, fmt.Errorf("please validate username/password and account/role")
+	}
+
+	if sr.RequestFailed() {
+		return nil, fmt.Errorf("Error creating session: %s", strings.Join(sr.GetErrors(), ", "))
 	}
 
 	sr.Expires = time.Now().Local().Add(time.Hour * time.Duration(sessionDuration))

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -1,8 +1,9 @@
 package alks
 
 import (
-	. "github.com/motain/gocheck"
 	"time"
+
+	. "github.com/motain/gocheck"
 )
 
 func (s *S) Test_CreateSession(c *C) {
@@ -71,7 +72,7 @@ func (s *S) Test_GetAccountsPowerUser(c *C) {
 
 	c.Assert(err, IsNil)
 	c.Assert(resp, NotNil)
-	var index int = getIndexByAccount(resp.Accounts, "123456/ALKSPowerUser - foobarbaz")
+	var index = getIndexByAccount(resp.Accounts, "123456/ALKSPowerUser - foobarbaz")
 	c.Assert(resp.Accounts[index].Account, Equals, "123456/ALKSPowerUser - foobarbaz") // make sure account name is transformed to key
 	c.Assert(resp.Accounts[index].Role, Equals, "PowerUser")
 	c.Assert(resp.Accounts[index].IamActive, Equals, false)
@@ -86,7 +87,7 @@ func (s *S) Test_GetAccountsIAMAdmin(c *C) {
 
 	c.Assert(err, IsNil)
 	c.Assert(resp, NotNil)
-	var index int = getIndexByAccount(resp.Accounts, "234567/ALKSIAMAdmin - foobarbaz2")
+	var index = getIndexByAccount(resp.Accounts, "234567/ALKSIAMAdmin - foobarbaz2")
 	c.Assert(resp.Accounts[index].Account, Equals, "234567/ALKSIAMAdmin - foobarbaz2") // make sure account name is transformed to key
 	c.Assert(resp.Accounts[index].Role, Equals, "IAMAdmin")
 	c.Assert(resp.Accounts[index].IamActive, Equals, true)
@@ -101,7 +102,7 @@ func (s *S) Test_GetAccountsAdmin(c *C) {
 
 	c.Assert(err, IsNil)
 	c.Assert(resp, NotNil)
-	var index int = getIndexByAccount(resp.Accounts, "345678/ALKSAdmin - foobarbaz3")
+	var index = getIndexByAccount(resp.Accounts, "345678/ALKSAdmin - foobarbaz3")
 	c.Assert(resp.Accounts[index].Account, Equals, "345678/ALKSAdmin - foobarbaz3") // make sure account name is transformed to key
 	c.Assert(resp.Accounts[index].Role, Equals, "Admin")
 	c.Assert(resp.Accounts[index].IamActive, Equals, true)


### PR DESCRIPTION
Started off pulling the thread around error reporting/handling.  Ended up also including a small refactor to break ALKS credentials into dedicated helpers and added support for Okta bearer tokens.

Change List:

- Added dedicated ALKS credential types (Basic, STS, and Bearer)
- Added a `BaseResponse` type to DRY and simplify error checking/reporting
- Cleaned up doc strings to satisfy basic Go standards
- Cleaned up a few linter warnings about naming and formatting