### PR TITLE
Add LTK Endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# GoLand
+*.idea

--- a/iam_ltk.go
+++ b/iam_ltk.go
@@ -1,6 +1,7 @@
 package alks
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -18,6 +19,41 @@ type LongTermKey struct {
 type GetLongTermKeysResponse struct {
 	BaseResponse
 	LongTermKeys []LongTermKey `json:"longTermKeys"`
+}
+
+// CreateLongTermKey represents the response from API
+type CreateLongTermKey struct {
+	Account             string `json:"account"`
+	Action              string `json:"action"`
+	IAMUserName         string `json:"iamUserName"`
+	IAMUserArn          string `json:"iamUserArn"`
+	AddedIAMUserToGroup bool   `json:"addedIAMUserToGroup"`
+	PartialError        bool   `json:"partialError"`
+}
+
+// LongTermKeyRequest is used to represent the request body to create or delete LTKs
+type LongTermKeyRequest struct {
+	Account     string `json:"account"`
+	Role        string `json:"role"`
+	IamUserName string `json:"iamUserName"`
+}
+
+// CreateLongTermKeyResponse is the response to the CLI client
+type CreateLongTermKeyResponse struct {
+	BaseResponse
+	CreateLongTermKey
+}
+
+// DeleteLongTermKey represents the response from API
+type DeleteLongTermKey struct {
+	AddedIAMUserToGroup bool `json:"addedIAMUserToGroup"`
+	PartialError        bool `json:"partialError"`
+}
+
+// DeleteLongTermKeyResponse is the response to the CLI client
+type DeleteLongTermKeyResponse struct {
+	BaseResponse
+	DeleteLongTermKey
 }
 
 // GetLongTermKeys gets the LTKs for an account
@@ -51,4 +87,94 @@ func (c *Client) GetLongTermKeys(accountId string, roleName string) (*GetLongTer
 	}
 
 	return cr, nil
+}
+
+// CreateLongTermKeys creates an LTK user for an account.
+// If no error is returned, then you will receive an appropriate success message.
+func (c *Client) CreateLongTermKey(accountId string, roleName string, accountAlias string, iamUsername string) (*CreateLongTermKeyResponse, error) {
+	log.Printf("[INFO] Creating long term key for: %s/%s - %s", accountId, roleName, accountAlias)
+
+	request := LongTermKeyRequest{
+		Account:     accountId + "/ALKS" + roleName + " - " + accountAlias,
+		Role:        roleName,
+		IamUserName: iamUsername,
+	}
+
+	reqBody, err := json.Marshal(struct{ LongTermKeyRequest }{request})
+
+	if err!= nil {
+		return nil, fmt.Errorf("error encoding LTK create JSON: %s", err)
+	}
+
+	req, err := c.NewRequest(reqBody, "POST", "/accessKeys")
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	cr := new(CreateLongTermKeyResponse)
+	err = decodeBody(resp, &cr)
+
+	if err != nil {
+		if reqId := GetRequestID(resp); reqId != "" {
+			return nil, fmt.Errorf("error parsing CreateLongTermKeyResponse: [%s] %s", reqId, err)
+		}
+
+		return nil, fmt.Errorf("error parsing CreateLongTermKeyResponse: %s", err)
+	}
+
+	if cr.RequestFailed() {
+		return nil, fmt.Errorf("error creating long term key: [%s] %s", cr.BaseResponse.RequestID, strings.Join(cr.GetErrors(), ", "))
+	}
+
+	return cr, nil
+}
+
+// DeleteLongTermKeys deletes an LTK user for an account.
+// If no error is returned, then you will receive an appropriate success message.
+func (c *Client) DeleteLongTermKey(accountId string, roleName string, accountAlias string, iamUsername string) (*DeleteLongTermKeyResponse, error) {
+	log.Printf("[INFO] Deleting long term key user for: %s/%s - %s", accountId, roleName, accountAlias)
+
+	request := LongTermKeyRequest{
+		Account:     accountId + "/ALKS" + roleName + " - " + accountAlias,
+		Role:        roleName,
+		IamUserName: iamUsername,
+	}
+	reqBody, err := json.Marshal(struct{ LongTermKeyRequest }{request})
+
+	if err != nil {
+		return nil, fmt.Errorf("error encoding LTK delete JSON: %s", err)
+	}
+
+	req, err := c.NewRequest(reqBody, "DELETE", "/IAMUser")
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	cr := new(DeleteLongTermKeyResponse)
+	err = decodeBody(resp, &cr)
+
+	if err != nil {
+		if reqId := GetRequestID(resp); reqId != "" {
+			return nil, fmt.Errorf("error parsing DeleteLongTermKeyResponse: [%s] %s", reqId, err)
+		}
+
+		return nil, fmt.Errorf("error parsing DeleteLongTermKeyResponse: %s", err)
+	}
+
+	if cr.RequestFailed() {
+		return nil, fmt.Errorf("error deleting long term key: [%s] %s", cr.BaseResponse.RequestID, strings.Join(cr.GetErrors(), ", "))
+	}
+
+	return cr, nil
+
 }

--- a/iam_ltk.go
+++ b/iam_ltk.go
@@ -29,6 +29,8 @@ type CreateLongTermKey struct {
 	IAMUserArn          string `json:"iamUserArn"`
 	AddedIAMUserToGroup bool   `json:"addedIAMUserToGroup"`
 	PartialError        bool   `json:"partialError"`
+	AccessKey           string `json:"accessKey"`
+	SecretKey           string `json:"secretKey"`
 }
 
 // LongTermKeyRequest is used to represent the request body to create or delete LTKs
@@ -102,7 +104,7 @@ func (c *Client) CreateLongTermKey(accountId string, roleName string, accountAli
 
 	reqBody, err := json.Marshal(struct{ LongTermKeyRequest }{request})
 
-	if err!= nil {
+	if err != nil {
 		return nil, fmt.Errorf("error encoding LTK create JSON: %s", err)
 	}
 

--- a/iam_ltk.go
+++ b/iam_ltk.go
@@ -36,7 +36,6 @@ type CreateLongTermKey struct {
 // LongTermKeyRequest is used to represent the request body to create or delete LTKs
 type LongTermKeyRequest struct {
 	Account     string `json:"account"`
-	Role        string `json:"role"`
 	IamUserName string `json:"iamUserName"`
 }
 
@@ -98,7 +97,6 @@ func (c *Client) CreateLongTermKey(accountId string, roleName string, accountAli
 
 	request := LongTermKeyRequest{
 		Account:     accountId + "/ALKS" + roleName + " - " + accountAlias,
-		Role:        roleName,
 		IamUserName: iamUsername,
 	}
 
@@ -143,7 +141,6 @@ func (c *Client) DeleteLongTermKey(accountId string, roleName string, accountAli
 
 	request := LongTermKeyRequest{
 		Account:     accountId + "/ALKS" + roleName + " - " + accountAlias,
-		Role:        roleName,
 		IamUserName: iamUsername,
 	}
 	reqBody, err := json.Marshal(struct{ LongTermKeyRequest }{request})

--- a/iam_ltk_test.go
+++ b/iam_ltk_test.go
@@ -28,9 +28,10 @@ func (s *S) Test_CreateLongTermKeys(c *C) {
 		IAMUserArn:          "arn:aws:iam::012345678910:user/acct-managed/MY_USERNAME",
 		AddedIAMUserToGroup: true,
 		PartialError:        false,
+		AccessKey:           "thisismykey",
+		SecretKey:           "secret/thisismysecret",
 	})
 }
-
 
 func (s *S) Test_DeleteLongTermKeys(c *C) {
 	testServer.Response(202, nil, deleteLongTermKeys)
@@ -58,7 +59,9 @@ var createLongTermKeys = `
     "iamUserName": "MY_USERNAME",
     "iamUserArn": "arn:aws:iam::012345678910:user/acct-managed/MY_USERNAME",
     "addedIAMUserToGroup": true,
-    "partialError": false
+    "partialError": false,
+	"accessKey": "thisismykey",
+    "secretKey": "secret/thisismysecret"
 }
 `
 

--- a/iam_ltk_test.go
+++ b/iam_ltk_test.go
@@ -15,6 +15,53 @@ func (s *S) Test_GetLongTermKeys(c *C) {
 	c.Assert(resp.LongTermKeys, DeepEquals, []LongTermKey{LongTermKey{UserName: "bob", AccessKeyID: "verySecret", Status: "Active", CreateDate: "2020-04-20"}})
 }
 
+func (s *S) Test_CreateLongTermKeys(c *C) {
+	testServer.Response(202, nil, createLongTermKeys)
+
+	resp, err := s.client.CreateLongTermKey("012345678910", "Admin", "AccountAlias", "MY_USERNAME")
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.CreateLongTermKey, DeepEquals, CreateLongTermKey{
+		Account:             "012345678910/ALKSAdmin - AccountAlias",
+		Action:              "CREATE",
+		IAMUserName:         "MY_USERNAME",
+		IAMUserArn:          "arn:aws:iam::012345678910:user/acct-managed/MY_USERNAME",
+		AddedIAMUserToGroup: true,
+		PartialError:        false,
+	})
+}
+
+
+func (s *S) Test_DeleteLongTermKeys(c *C) {
+	testServer.Response(202, nil, deleteLongTermKeys)
+
+	resp, err := s.client.DeleteLongTermKey("012345678910", "myRole", "accountAlias", "MyUserName")
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.DeleteLongTermKey, DeepEquals, DeleteLongTermKey{
+		AddedIAMUserToGroup: false,
+		PartialError:        false,
+	})
+}
+
+var deleteLongTermKeys = `
+{
+  "addedIAMUserToGroup": false,
+  "partialError": false
+}
+`
+
+var createLongTermKeys = `
+{
+    "account": "012345678910/ALKSAdmin - AccountAlias",
+    "action": "CREATE",
+    "iamUserName": "MY_USERNAME",
+    "iamUserArn": "arn:aws:iam::012345678910:user/acct-managed/MY_USERNAME",
+    "addedIAMUserToGroup": true,
+    "partialError": false
+}
+`
+
 var longTermKeys = `
 {
 	"longTermKeys": [


### PR DESCRIPTION
This PR adds the new `POST: /accessKeys` and `DEL: /IAMUser` endpoints. These endpoints will create and delete LTK users. I've made sure to _not_ include the `accessKey` & `secretKey` from the response as not to expose unwanted data. 

I've also included the appropriate tests. All is working / passing on my end. 

Good luck reviewer 👍 