### PR TITLE
Refactor LTK methods

### DIFF
--- a/account_details.go
+++ b/account_details.go
@@ -1,0 +1,95 @@
+package alks
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+// This regex will attempt to parse ALKS account strings (and must be valid for the package to compile)
+// *** WARNING ***: The group names in the regex are referenced below, changing them means updating the associated methods as well
+var accountRegex = regexp.MustCompile(`(?P<AccountNumber>\d+)(/(?P<RoleName>(ALKS)?\w+)(\s-\s(?P<AccountDesc>\w+))?)?`)
+
+// AccountDetails represents the callers Account and Role information for ALKS requests
+type AccountDetails struct {
+	Account string `json:"account,omitempty"`
+	Role    string `json:"role,omitempty"`
+}
+
+// GetAccountNumber parses the Account provided in AccountDetails and returns the account number if present
+func (a AccountDetails) GetAccountNumber() (string, error) {
+	if a.Account == "" {
+		return "", errors.New("Account is empty")
+	}
+
+	if accountRegex.MatchString(a.Account) {
+		matches := accountRegex.FindStringSubmatch(a.Account)
+
+		for i, v := range accountRegex.SubexpNames() {
+			if v == "AccountNumber" {
+				return matches[i], nil
+			}
+		}
+	}
+
+	return "", errors.New("Invalid Account format")
+}
+
+// GetRoleName returns the AccountDetails Role or parses the role value from the Account
+func (a AccountDetails) GetRoleName(stripPrefix bool) (string, error) {
+	if a.Role != "" {
+		if stripPrefix {
+			return strings.TrimPrefix(a.Role, "ALKS"), nil
+		}
+
+		return a.Role, nil
+	}
+
+	if a.Account == "" {
+		return "", errors.New("Account is empty")
+	}
+
+	if accountRegex.MatchString(a.Account) {
+		matches := accountRegex.FindStringSubmatch(a.Account)
+
+		for i, v := range accountRegex.SubexpNames() {
+			if v == "RoleName" {
+				roleName := matches[i]
+				if roleName == "" {
+					return "", errors.New("No Role found")
+				}
+
+				if stripPrefix {
+					return strings.TrimPrefix(roleName, "ALKS"), nil
+				}
+
+				return roleName, nil
+			}
+		}
+	}
+
+	return "", errors.New("Invalid Account format")
+}
+
+// GetAccountDesc parses the Account provided in AccountDetails and returns the account description if present
+func (a AccountDetails) GetAccountDesc() (string, error) {
+	if a.Account == "" {
+		return "", errors.New("Account is empty")
+	}
+
+	if accountRegex.MatchString(a.Account) {
+		matches := accountRegex.FindStringSubmatch(a.Account)
+
+		for i, v := range accountRegex.SubexpNames() {
+			if v == "AccountDesc" {
+				if matches[i] == "" {
+					return "", errors.New("No AccountDesc found")
+				}
+
+				return matches[i], nil
+			}
+		}
+	}
+
+	return "", errors.New("Invalid Account format")
+}

--- a/api.go
+++ b/api.go
@@ -14,12 +14,6 @@ import (
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 )
 
-// AccountDetails represents the callers Account and Role information for ALKS requests
-type AccountDetails struct {
-	Account string `json:"account,omitempty"`
-	Role    string `json:"role,omitempty"`
-}
-
 // Client represents an ALKS client and contains the account info and base url.
 type Client struct {
 	Credentials    AuthInjecter

--- a/iam_ltk.go
+++ b/iam_ltk.go
@@ -44,6 +44,7 @@ type LongTermKeyRequest struct {
 
 // CreateLongTermKeyResponse is the response to the CLI client
 type CreateLongTermKeyResponse struct {
+	AccountDetails
 	BaseResponse
 	BaseLongTermKeyResponse
 	CreateLongTermKey
@@ -51,6 +52,7 @@ type CreateLongTermKeyResponse struct {
 
 // DeleteLongTermKeyResponse is the response to the CLI client
 type DeleteLongTermKeyResponse struct {
+	AccountDetails
 	BaseResponse
 	BaseLongTermKeyResponse
 }

--- a/iam_ltk.go
+++ b/iam_ltk.go
@@ -23,14 +23,13 @@ type GetLongTermKeysResponse struct {
 
 // BaseLongTermKeyResponse encapsulates shared response fields
 type BaseLongTermKeyResponse struct {
-	AddedIAMUserToGroup bool `json:"addedIAMUserToGroup,omitempty"`
-	PartialError        bool `json:"partialError,omitempty"`
+	Action              string `json:"action,omitempty"`
+	AddedIAMUserToGroup bool   `json:"addedIAMUserToGroup,omitempty"`
+	PartialError        bool   `json:"partialError,omitempty"`
 }
 
 // CreateLongTermKey represents the response from API
 type CreateLongTermKey struct {
-	Account     string `json:"account"`
-	Action      string `json:"action"`
 	IAMUserName string `json:"iamUserName"`
 	IAMUserArn  string `json:"iamUserArn"`
 	AccessKey   string `json:"accessKey"`
@@ -39,8 +38,8 @@ type CreateLongTermKey struct {
 
 // LongTermKeyRequest is used to represent the request body to create or delete LTKs
 type LongTermKeyRequest struct {
-	AccountDetails AccountDetails
-	IamUserName    string `json:"iamUserName"`
+	AccountDetails
+	IamUserName string `json:"iamUserName"`
 }
 
 // CreateLongTermKeyResponse is the response to the CLI client

--- a/iam_ltk.go
+++ b/iam_ltk.go
@@ -58,10 +58,10 @@ type DeleteLongTermKeyResponse struct {
 
 // GetLongTermKeys gets the LTKs for an account
 // If no error is returned then you will receive a list of LTKs
-func (c *Client) GetLongTermKeys(accountId string, roleName string) (*GetLongTermKeysResponse, error) {
-	log.Printf("[INFO] Getting long term keys for: %s/%s", accountId, roleName)
+func (c *Client) GetLongTermKeys(accountID string, roleName string) (*GetLongTermKeysResponse, error) {
+	log.Printf("[INFO] Getting long term keys for: %s/%s", accountID, roleName)
 
-	req, err := c.NewRequest(nil, "GET", "/ltks/"+accountId+"/"+roleName)
+	req, err := c.NewRequest(nil, "GET", "/ltks/"+accountID+"/"+roleName)
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +75,8 @@ func (c *Client) GetLongTermKeys(accountId string, roleName string) (*GetLongTer
 	err = decodeBody(resp, &cr)
 
 	if err != nil {
-		if reqId := GetRequestID(resp); reqId != "" {
-			return nil, fmt.Errorf("Error parsing GetLongTermKeysResponse: [%s] %s", reqId, err)
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf("Error parsing GetLongTermKeysResponse: [%s] %s", reqID, err)
 		}
 
 		return nil, fmt.Errorf("Error parsing GetLongTermKeysResponse: %s", err)
@@ -119,8 +119,8 @@ func (c *Client) CreateLongTermKey(iamUsername string) (*CreateLongTermKeyRespon
 	err = decodeBody(resp, &cr)
 
 	if err != nil {
-		if reqId := GetRequestID(resp); reqId != "" {
-			return nil, fmt.Errorf("error parsing CreateLongTermKeyResponse: [%s] %s", reqId, err)
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf("error parsing CreateLongTermKeyResponse: [%s] %s", reqID, err)
 		}
 
 		return nil, fmt.Errorf("error parsing CreateLongTermKeyResponse: %s", err)
@@ -163,8 +163,8 @@ func (c *Client) DeleteLongTermKey(iamUsername string) (*DeleteLongTermKeyRespon
 	err = decodeBody(resp, &cr)
 
 	if err != nil {
-		if reqId := GetRequestID(resp); reqId != "" {
-			return nil, fmt.Errorf("error parsing DeleteLongTermKeyResponse: [%s] %s", reqId, err)
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf("error parsing DeleteLongTermKeyResponse: [%s] %s", reqID, err)
 		}
 
 		return nil, fmt.Errorf("error parsing DeleteLongTermKeyResponse: %s", err)

--- a/iam_ltk.go
+++ b/iam_ltk.go
@@ -59,8 +59,18 @@ type DeleteLongTermKeyResponse struct {
 
 // GetLongTermKeys gets the LTKs for an account
 // If no error is returned then you will receive a list of LTKs
-func (c *Client) GetLongTermKeys(accountID string, roleName string) (*GetLongTermKeysResponse, error) {
-	log.Printf("[INFO] Getting long term keys for: %s/%s", accountID, roleName)
+func (c *Client) GetLongTermKeys() (*GetLongTermKeysResponse, error) {
+	log.Printf("[INFO] Getting long term keys")
+
+	accountID, err := c.AccountDetails.GetAccountNumber()
+	if err != nil {
+		return nil, fmt.Errorf("Error reading Account value: %s", err)
+	}
+
+	roleName, err := c.AccountDetails.GetRoleName(false)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading Role value: %s", err)
+	}
 
 	req, err := c.NewRequest(nil, "GET", "/ltks/"+accountID+"/"+roleName)
 	if err != nil {

--- a/iam_ltk_test.go
+++ b/iam_ltk_test.go
@@ -18,28 +18,30 @@ func (s *S) Test_GetLongTermKeys(c *C) {
 func (s *S) Test_CreateLongTermKeys(c *C) {
 	testServer.Response(202, nil, createLongTermKeys)
 
-	resp, err := s.client.CreateLongTermKey("012345678910", "Admin", "AccountAlias", "MY_USERNAME")
+	resp, err := s.client.CreateLongTermKey("MY_USERNAME")
 
 	c.Assert(err, IsNil)
 	c.Assert(resp.CreateLongTermKey, DeepEquals, CreateLongTermKey{
-		Account:             "012345678910/ALKSAdmin - AccountAlias",
-		Action:              "CREATE",
-		IAMUserName:         "MY_USERNAME",
-		IAMUserArn:          "arn:aws:iam::012345678910:user/acct-managed/MY_USERNAME",
+		Account:     "012345678910/ALKSAdmin - AccountAlias",
+		Action:      "CREATE",
+		IAMUserName: "MY_USERNAME",
+		IAMUserArn:  "arn:aws:iam::012345678910:user/acct-managed/MY_USERNAME",
+		AccessKey:   "thisismykey",
+		SecretKey:   "secret/thisismysecret",
+	})
+	c.Assert(resp.BaseLongTermKeyResponse, DeepEquals, BaseLongTermKeyResponse{
 		AddedIAMUserToGroup: true,
 		PartialError:        false,
-		AccessKey:           "thisismykey",
-		SecretKey:           "secret/thisismysecret",
 	})
 }
 
 func (s *S) Test_DeleteLongTermKeys(c *C) {
 	testServer.Response(202, nil, deleteLongTermKeys)
 
-	resp, err := s.client.DeleteLongTermKey("012345678910", "myRole", "accountAlias", "MyUserName")
+	resp, err := s.client.DeleteLongTermKey("MyUserName")
 
 	c.Assert(err, IsNil)
-	c.Assert(resp.DeleteLongTermKey, DeepEquals, DeleteLongTermKey{
+	c.Assert(resp.BaseLongTermKeyResponse, DeepEquals, BaseLongTermKeyResponse{
 		AddedIAMUserToGroup: false,
 		PartialError:        false,
 	})

--- a/iam_ltk_test.go
+++ b/iam_ltk_test.go
@@ -7,7 +7,7 @@ import (
 func (s *S) Test_GetLongTermKeys(c *C) {
 	testServer.Response(202, nil, longTermKeys)
 
-	resp, err := s.client.GetLongTermKeys("012345678910", "myRole")
+	resp, err := s.client.GetLongTermKeys()
 
 	_ = testServer.WaitRequest()
 

--- a/iam_ltk_test.go
+++ b/iam_ltk_test.go
@@ -22,14 +22,13 @@ func (s *S) Test_CreateLongTermKeys(c *C) {
 
 	c.Assert(err, IsNil)
 	c.Assert(resp.CreateLongTermKey, DeepEquals, CreateLongTermKey{
-		Account:     "012345678910/ALKSAdmin - AccountAlias",
-		Action:      "CREATE",
 		IAMUserName: "MY_USERNAME",
 		IAMUserArn:  "arn:aws:iam::012345678910:user/acct-managed/MY_USERNAME",
 		AccessKey:   "thisismykey",
 		SecretKey:   "secret/thisismysecret",
 	})
 	c.Assert(resp.BaseLongTermKeyResponse, DeepEquals, BaseLongTermKeyResponse{
+		Action:              "CREATE",
 		AddedIAMUserToGroup: true,
 		PartialError:        false,
 	})

--- a/iam_role.go
+++ b/iam_role.go
@@ -414,8 +414,8 @@ func (c *Client) SearchRoleMachineIdentity(roleARN string) (*MachineIdentityResp
 	err = decodeBody(resp, &sr)
 
 	if err != nil {
-		if reqId := GetRequestID(resp); reqId != "" {
-			return nil, fmt.Errorf("Error parsing MachineIdentityResponse: [%s] %s", reqId, err)
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf("Error parsing MachineIdentityResponse: [%s] %s", reqID, err)
 		}
 
 		return nil, fmt.Errorf("Error parsing MachineIdentityResponse: %s", err)


### PR DESCRIPTION
This PR refactors the new LTK methods to perform a little clean up and make them conform to the existing code base conventions.  I also took the opportunity to apply a couple linter warnings about naming acronyms with camel case.