### PR TITLE
Get Single LTK Endpoint

### DIFF
--- a/iam_ltk.go
+++ b/iam_ltk.go
@@ -115,19 +115,19 @@ func (c *Client) GetLongTermKey(iamUsername string) (*GetLongTermKeyResponse, er
 	var req *http.Request
 	var err error
 
-	accountID, err := c.AccountDetails.GetAccountNumber()
-	if err != nil {
-		return nil, fmt.Errorf("error reading Account value: %s", err)
-	}
-
-	roleName, err := c.AccountDetails.GetRoleName(false)
-	if err != nil {
-		return nil, fmt.Errorf("error reading Role value: %s", err)
-	}
-
 	if c.IsUsingSTSCredentials() {
 		req, err = c.NewRequest(nil, "GET", "/ltk/search/"+iamUsername)
 	} else {
+		accountID, err := c.AccountDetails.GetAccountNumber()
+		if err != nil {
+			return nil, fmt.Errorf("error reading Account value: %s", err)
+		}
+
+		roleName, err := c.AccountDetails.GetRoleName(false)
+		if err != nil {
+			return nil, fmt.Errorf("error reading Role value: %s", err)
+		}
+
 		req, err = c.NewRequest(nil, "GET", "/ltk/"+accountID+"/"+roleName+"/search/"+iamUsername)
 	}
 

--- a/iam_ltk.go
+++ b/iam_ltk.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 )
 
@@ -111,7 +112,25 @@ func (c *Client) GetLongTermKeys() (*GetLongTermKeysResponse, error) {
 func (c *Client) GetLongTermKey(iamUsername string) (*GetLongTermKeyResponse, error) {
 	log.Printf("[INFO] Getting long term key")
 
-	req, err := c.NewRequest(nil, "GET", "/ltk/search/"+iamUsername)
+	var req *http.Request
+	var err error
+
+	accountID, err := c.AccountDetails.GetAccountNumber()
+	if err != nil {
+		return nil, fmt.Errorf("error reading Account value: %s", err)
+	}
+
+	roleName, err := c.AccountDetails.GetRoleName(false)
+	if err != nil {
+		return nil, fmt.Errorf("error reading Role value: %s", err)
+	}
+
+	if c.IsUsingSTSCredentials() {
+		req, err = c.NewRequest(nil, "GET", "/ltk/search/"+iamUsername)
+	} else {
+		req, err = c.NewRequest(nil, "GET", "/ltk/"+accountID+"/"+roleName+"/search/"+iamUsername)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/iam_ltk_test.go
+++ b/iam_ltk_test.go
@@ -12,7 +12,18 @@ func (s *S) Test_GetLongTermKeys(c *C) {
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
-	c.Assert(resp.LongTermKeys, DeepEquals, []LongTermKey{LongTermKey{UserName: "bob", AccessKeyID: "verySecret", Status: "Active", CreateDate: "2020-04-20"}})
+	c.Assert(resp.LongTermKeys, DeepEquals, []LongTermKey{{UserName: "bob", AccessKeyID: "verySecret", Status: "Active", CreateDate: "2020-04-20"}})
+}
+
+func (s *S) Test_GetLongTermKey(c *C) {
+	testServer.Response(202, nil, longTermKey)
+
+	resp, err := s.client.GetLongTermKey("bob")
+
+	_ = testServer.WaitRequest()
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.LongTermKey, DeepEquals, LongTermKey{})
 }
 
 func (s *S) Test_CreateLongTermKeys(c *C) {
@@ -76,5 +87,14 @@ var longTermKeys = `
 			"createDate": "2020-04-20"
 		}
 	]
+}
+`
+
+var longTermKey = `
+{
+	"userName": "bob",
+	"accessKeyId": "verySecret",
+	"status": "Active",
+	"createDate": "2020-04-20"
 }
 `


### PR DESCRIPTION
This PR adds a new endpoint to retrieve a single LTK user from the current account with account information inferred from STS credentials. This is working in both the tests as well as my local test suite.

Also cleaned up another test to remove redundant variable which Go's linter was complaining about. Did not affect the test results, simply cleaned up the code.