### PR TITLE
Automatically populate AccountDetails from STS credentials

### DIFF
--- a/api.go
+++ b/api.go
@@ -91,6 +91,16 @@ func (c *Client) SetUserAgent(userAgent string) {
 	c.userAgent = userAgent
 }
 
+// IsUsingSTSCredentials returns a boolean indicating if the client was configured using AWS STS Credentials for authentication
+func (c *Client) IsUsingSTSCredentials() bool {
+	switch c.Credentials.(type) {
+	case *STS:
+		return true
+	default:
+		return false
+	}
+}
+
 // NewRequest will create a new request object for API requests.
 func (c *Client) NewRequest(json []byte, method string, endpoint string) (*http.Request, error) {
 	u, err := url.Parse(c.BaseURL + endpoint)

--- a/api.go
+++ b/api.go
@@ -64,6 +64,13 @@ func NewSTSClient(url string, accessKey string, secretKey string, token string) 
 		userAgent:   "alks-go",
 	}
 
+	// Fetch the current login role, and try to populate the account details object.  If we fail, just ignore
+	loginRole, err := client.GetMyLoginRole()
+	if err == nil {
+		client.AccountDetails.Account = loginRole.LoginRole.Account
+		client.AccountDetails.Role = loginRole.LoginRole.Role
+	}
+
 	return &client, nil
 }
 

--- a/login_role.go
+++ b/login_role.go
@@ -1,0 +1,89 @@
+package alks
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+// GetMyLoginRole returns the LoginRole corresponding to the clients current STS credentials
+func (c *Client) GetMyLoginRole() (*LoginRoleResponse, error) {
+	log.Printf("[INFO] Requesting Login Role information from ALKS")
+
+	if !c.IsUsingSTSCredentials() {
+		return nil, fmt.Errorf("GetMyLoginRole only supports clients using STS credentials, try using GetLoginRole instead")
+	}
+
+	req, err := c.NewRequest(nil, "GET", "/loginRoles/id/me")
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	lrr := new(LoginRoleResponse)
+	err = decodeBody(resp, &lrr)
+	if err != nil {
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf("Error parsing LoginRole response: [%s] %s", reqID, err)
+		}
+
+		return nil, fmt.Errorf("Error parsing LoginRole response: %s", err)
+	}
+
+	if lrr.RequestFailed() {
+		return nil, fmt.Errorf("Error fetching role information: [%s] %s", lrr.BaseResponse.RequestID, strings.Join(lrr.GetErrors(), ", "))
+	}
+
+	return lrr, nil
+}
+
+// GetLoginRole returns the login role corresponding to the current account and role stored in AccountDetails
+func (c *Client) GetLoginRole() (*LoginRoleResponse, error) {
+	// If the client is configured with STS call the correct method
+	if c.IsUsingSTSCredentials() {
+		log.Println("[INFO] Client configured with STS credentials, dispatching to GetMyLoginRole instead")
+		return c.GetMyLoginRole()
+	}
+
+	account, err := c.AccountDetails.GetAccountNumber()
+	if err != nil {
+		return nil, err
+	}
+
+	roleName, err := c.AccountDetails.GetRoleName(false)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("[INFO] Requesting Login Role information for %v/%v from ALKS", account, roleName)
+
+	req, err := c.NewRequest(nil, "GET", fmt.Sprintf("/loginRoles/id/%v/%v", account, roleName))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	lrr := new(LoginRoleResponse)
+	err = decodeBody(resp, &lrr)
+	if err != nil {
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf("Error parsing LoginRole response: [%s] %s", reqID, err)
+		}
+
+		return nil, fmt.Errorf("Error parsing LoginRole response: %s", err)
+	}
+
+	if lrr.RequestFailed() {
+		return nil, fmt.Errorf("Error fetching role information: [%s] %s", lrr.BaseResponse.RequestID, strings.Join(lrr.GetErrors(), ", "))
+	}
+
+	return lrr, nil
+}

--- a/login_role_test.go
+++ b/login_role_test.go
@@ -1,0 +1,38 @@
+package alks
+
+import (
+	. "github.com/motain/gocheck"
+)
+
+func (s *S) Test_GetMyLoginRole(c *C) {
+	testServer.Response(200, nil, getIamLoginRoleResponse)
+
+	oldCreds := s.client.Credentials
+	s.client.Credentials = &STS{AccessKey: "abc", SecretKey: "123", SessionToken: "abc123"}
+
+	resp, err := s.client.GetMyLoginRole()
+
+	_ = testServer.WaitRequest()
+
+	c.Assert(resp.LoginRole.Account, Equals, "012345678910/ALKSAdmin")
+	c.Assert(resp.LoginRole.IamKeyActive, Equals, true)
+	c.Assert(resp.LoginRole.MaxKeyDuration, Equals, 36)
+	c.Assert(resp.LoginRole.Role, Equals, "Admin")
+	c.Assert(err, IsNil)
+
+	s.client.Credentials = oldCreds
+}
+
+func (s *S) Test_GetLoginRole(c *C) {
+	testServer.Response(200, nil, getIamLoginRoleResponse)
+
+	resp, err := s.client.GetLoginRole()
+
+	_ = testServer.WaitRequest()
+
+	c.Assert(resp.LoginRole.Account, Equals, "012345678910/ALKSAdmin")
+	c.Assert(resp.LoginRole.IamKeyActive, Equals, true)
+	c.Assert(resp.LoginRole.MaxKeyDuration, Equals, 36)
+	c.Assert(resp.LoginRole.Role, Equals, "Admin")
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
This PR adds the `/loginRoles` endpoint methods and uses them when creating a new STS client to determine the Account ID and current role name for some API calls.