### PR TITLE
Support dynamic roles

### DIFF
--- a/iam_role.go
+++ b/iam_role.go
@@ -10,10 +10,11 @@ import (
 
 // IamRoleRequest is used to represent a new IAM Role request.
 type IamRoleRequest struct {
-	RoleName   string `json:"roleName"`
-	RoleType   string `json:"roleType"`
-	IncDefPols int    `json:"includeDefaultPolicy"`
-	AlksAccess bool   `json:"enableAlksAccess"`
+	RoleName       string            `json:"roleName"`
+	RoleType       string            `json:"roleType"`
+	IncDefPols     int               `json:"includeDefaultPolicy"`
+	AlksAccess     bool              `json:"enableAlksAccess"`
+	TemplateFields map[string]string `json:"templateFields,omitempty"`
 }
 
 // IamTrustRoleRequest is used to represent a new IAM Trust Role request.
@@ -27,12 +28,13 @@ type IamTrustRoleRequest struct {
 // IamRoleResponse is used to represent a a IAM Role.
 type IamRoleResponse struct {
 	BaseResponse
-	RoleName      string `json:"roleName"`
-	RoleType      string `json:"roleType"`
-	RoleArn       string `json:"roleArn"`
-	RoleIPArn     string `json:"instanceProfileArn"`
-	RoleAddedToIP bool   `json:"addedRoleToInstanceProfile"`
-	Exists        bool   `json:"roleExists"`
+	RoleName       string            `json:"roleName"`
+	RoleType       string            `json:"roleType"`
+	RoleArn        string            `json:"roleArn"`
+	RoleIPArn      string            `json:"instanceProfileArn"`
+	RoleAddedToIP  bool              `json:"addedRoleToInstanceProfile"`
+	Exists         bool              `json:"roleExists"`
+	TemplateFields map[string]string `json:"templateFields,omitempty"`
 }
 
 // GetIamRoleResponse is used to represent a a IAM Role.
@@ -94,7 +96,7 @@ type MachineIdentityResponse struct {
 
 // CreateIamRole will create a new IAM role on AWS. If no error is returned
 // then you will receive a IamRoleResponse object representing the new role.
-func (c *Client) CreateIamRole(roleName string, roleType string, includeDefaultPolicies, enableAlksAccess bool) (*IamRoleResponse, error) {
+func (c *Client) CreateIamRole(roleName, roleType string, templateFields map[string]string, includeDefaultPolicies, enableAlksAccess bool) (*IamRoleResponse, error) {
 	log.Printf("[INFO] Creating IAM role: %s", roleName)
 
 	var include int
@@ -107,6 +109,7 @@ func (c *Client) CreateIamRole(roleName string, roleType string, includeDefaultP
 		roleType,
 		include,
 		enableAlksAccess,
+		templateFields,
 	}
 
 	b, err := json.Marshal(struct {

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -7,7 +7,7 @@ import (
 func (s *S) Test_CreateIamRole(c *C) {
 	testServer.Response(202, nil, iamGetRole)
 
-	resp, err := s.client.CreateIamRole("rolebae", "Admin", false, false)
+	resp, err := s.client.CreateIamRole("rolebae", "Admin", nil, false, false)
 
 	_ = testServer.WaitRequest()
 
@@ -15,6 +15,25 @@ func (s *S) Test_CreateIamRole(c *C) {
 	c.Assert(resp, NotNil)
 	c.Assert(resp.RoleName, Equals, "rolebae")
 	c.Assert(resp.RoleType, Equals, "Admin")
+}
+
+func (s *S) Test_CreateIamRoleTemplateFields(c *C) {
+	testServer.Response(202, nil, iamGetRoleTemplateFields)
+
+	templateFields := map[string]string{
+		"A": "B",
+		"C": "D",
+	}
+	resp, err := s.client.CreateIamRole("rolebae", "Admin", templateFields, false, false)
+
+	_ = testServer.WaitRequest()
+
+	c.Assert(err, IsNil)
+	c.Assert(resp, NotNil)
+	c.Assert(resp.RoleName, Equals, "rolebae")
+	c.Assert(resp.RoleType, Equals, "Admin")
+	c.Assert(resp.TemplateFields["A"], Equals, templateFields["A"])
+	c.Assert(resp.TemplateFields["C"], Equals, templateFields["C"])
 }
 
 func (s *S) Test_CreateIamTrustRole(c *C) {
@@ -106,8 +125,25 @@ var iamGetRole = `
     "instanceProfileArn": "aws:arn:foo:ip",
     "addedRoleToInstanceProfile": true,
     "errors": [],
-	"roleExists": true,
-	"machineIdentity": false
+		"roleExists": true,
+		"machineIdentity": false
+}
+`
+
+var iamGetRoleTemplateFields = `
+{
+    "roleName": "rolebae",
+    "roleType": "Admin",
+    "roleArn": "aws:arn:foo",
+    "instanceProfileArn": "aws:arn:foo:ip",
+    "addedRoleToInstanceProfile": true,
+    "errors": [],
+		"roleExists": true,
+		"machineIdentity": false,
+		"templateFields": {
+			"A": "B",
+			"C": "D"
+		}
 }
 `
 

--- a/response_base.go
+++ b/response_base.go
@@ -15,9 +15,7 @@ func (b BaseResponse) RequestFailed() bool {
 // GetErrors returns a list of error messages from an ALKS response
 func (b BaseResponse) GetErrors() []string {
 	var errorMessages []string
-	for _, err := range b.Errors {
-		errorMessages = append(errorMessages, err)
-	}
+	errorMessages = append(errorMessages, b.Errors...)
 
 	if len(errorMessages) == 0 {
 		errorMessages = []string{


### PR DESCRIPTION
This PR adds support for template fields in `CreateIamRole`.  Additionally, I cleaned up one linter warning about an unnecessary loop in `ResponseBase`.