### PR TITLE
Add tags to create role

### DIFF
--- a/iam_role.go
+++ b/iam_role.go
@@ -276,7 +276,7 @@ func updateOptions(o *IamRoleOptions) (options *IamRoleRequest, err error) {
 }
 
 // UpdateIamRole adds resource tags to an existing IAM role.
-func (c *Client) UpdateIamRole(options *IamRoleOptions) error {
+func (c *Client) UpdateIamRole(options *IamRoleOptions) (*IamRoleResponse, error) {
 	requestOptions, _ := updateOptions(options)
 	log.Printf("[INFO] Updating IAM role %s with Tags: %v", requestOptions.RoleName, requestOptions.Tags)
 
@@ -286,26 +286,26 @@ func (c *Client) UpdateIamRole(options *IamRoleOptions) error {
 
 	req, err := c.NewRequest(b, "POST", "/updateRole/")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	respObj := new(IamRoleResponse)
 	err = decodeBody(resp, &respObj)
 
 	if err != nil {
 		if reqID := GetRequestID(resp); reqID != "" {
-			return fmt.Errorf("Error parsing updateRole response: [%s] %s", reqID, err)
+			return nil, fmt.Errorf("Error parsing updateRole response: [%s] %s", reqID, err)
 		}
-		return fmt.Errorf("Error parsing updateRole response: %s", err)
+		return nil, fmt.Errorf("Error parsing updateRole response: %s", err)
 	}
 	if respObj.RequestFailed() {
-		return fmt.Errorf("Error updating role: [%s] %s", respObj.BaseResponse.RequestID, strings.Join(respObj.GetErrors(), ", "))
+		return nil, fmt.Errorf("Error updating role: [%s] %s", respObj.BaseResponse.RequestID, strings.Join(respObj.GetErrors(), ", "))
 	}
 
-	return nil
+	return respObj, nil
 }
 
 // DeleteIamRole will delete an existing IAM role from AWS. If no error is returned

--- a/iam_role.go
+++ b/iam_role.go
@@ -309,6 +309,9 @@ func (c *Client) makeIamRoleRequest(operation *requestOp) error {
 		}
 		return fmt.Errorf("error parsing updateRole response: %s", e)
 	}
+	if operation.Response.RequestFailed() {
+		return fmt.Errorf("error updating role: [%s] %s", *operation.Response.RoleName, strings.Join(operation.Response.GetErrors(), ", "))
+	}
 
 	return nil
 }
@@ -343,9 +346,6 @@ func (c *Client) UpdateIamRole(options func(*IamRoleInput)) (*IamRoleOutput, err
 	}
 	if e := c.makeIamRoleRequest(req); e != nil {
 		return nil, e
-	}
-	if req.Response.RequestFailed() {
-		return nil, fmt.Errorf("error updating role: [%s] %s", *input.RoleName, strings.Join(req.Response.GetErrors(), ", "))
 	}
 
 	return req.Response, nil

--- a/iam_role.go
+++ b/iam_role.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 )
 
+type Tag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
 type CreateIamRoleOptions struct {
 	RoleName                    *string
 	RoleType                    *string
@@ -16,6 +21,7 @@ type CreateIamRoleOptions struct {
 	TrustArn                    *string
 	TemplateFields              *map[string]string
 	MaxSessionDurationInSeconds *int
+	Tags                        *[]Tag
 }
 
 // IamRoleRequest is used to represent a new IAM Role request.
@@ -27,6 +33,7 @@ type IamRoleRequest struct {
 	TrustArn                    string            `json:"trustArn,omitempty"`
 	TemplateFields              map[string]string `json:"templateFields,omitempty"`
 	MaxSessionDurationInSeconds int               `json:"maxSessionDurationInSeconds"`
+	Tags                        []Tag             `json:"tags"`
 }
 
 // IamRoleResponse is used to represent a a IAM Role.
@@ -141,6 +148,12 @@ func NewIamRoleRequest(options *CreateIamRoleOptions) (*IamRoleRequest, error) {
 		iam.MaxSessionDurationInSeconds = *options.MaxSessionDurationInSeconds
 	} else {
 		iam.MaxSessionDurationInSeconds = 3600
+	}
+
+	if options.Tags != nil {
+		iam.Tags = *options.Tags
+	} else {
+		iam.Tags = nil
 	}
 
 	return iam, nil

--- a/iam_role.go
+++ b/iam_role.go
@@ -13,7 +13,7 @@ type Tag struct {
 	Value string `json:"value"`
 }
 
-type IamRoleOptions struct {
+type CreateIamRoleOptions struct {
 	RoleName                    *string
 	RoleType                    *string
 	IncludeDefaultPolicies      *bool
@@ -27,13 +27,13 @@ type IamRoleOptions struct {
 // IamRoleRequest is used to represent a new IAM Role request.
 type IamRoleRequest struct {
 	RoleName                    string            `json:"roleName"`
-	RoleType                    string            `json:"roleType,omitempty"`
-	IncDefPols                  int               `json:"includeDefaultPolicy,omitempty"`
-	AlksAccess                  bool              `json:"enableAlksAccess.omitempty"`
+	RoleType                    string            `json:"roleType"`
+	IncDefPols                  int               `json:"includeDefaultPolicy"`
+	AlksAccess                  bool              `json:"enableAlksAccess"`
 	TrustArn                    string            `json:"trustArn,omitempty"`
 	TemplateFields              map[string]string `json:"templateFields,omitempty"`
-	MaxSessionDurationInSeconds int               `json:"maxSessionDurationInSeconds,omitempty"`
-	Tags                        []Tag             `json:"tags,omitempty"`
+	MaxSessionDurationInSeconds int               `json:"maxSessionDurationInSeconds"`
+	Tags                        []Tag             `json:"tags"`
 }
 
 // IamRoleResponse is used to represent a a IAM Role.
@@ -107,7 +107,7 @@ type MachineIdentityResponse struct {
 }
 
 // Creates a new IamRoleRequest object from options
-func NewIamRoleRequest(options *IamRoleOptions) (*IamRoleRequest, error) {
+func NewIamRoleRequest(options *CreateIamRoleOptions) (*IamRoleRequest, error) {
 	if options.RoleName == nil {
 		return nil, fmt.Errorf("RoleName option must not be nil")
 	}
@@ -161,7 +161,7 @@ func NewIamRoleRequest(options *IamRoleOptions) (*IamRoleRequest, error) {
 
 // CreateIamRole will create a new IAM role in AWS. If no error is returned
 // then you will receive a IamRoleResponse object representing the new role.
-func (c *Client) CreateIamRole(options *IamRoleOptions) (*IamRoleResponse, error) {
+func (c *Client) CreateIamRole(options *CreateIamRoleOptions) (*IamRoleResponse, error) {
 	request, err := NewIamRoleRequest(options)
 
 	if err != nil {
@@ -209,7 +209,7 @@ func (c *Client) CreateIamRole(options *IamRoleOptions) (*IamRoleResponse, error
 
 // CreateIamTrustRole will create a new IAM trust role on AWS. If no error is returned
 // then you will receive a IamRoleResponse object representing the new role.
-func (c *Client) CreateIamTrustRole(options *IamRoleOptions) (*IamRoleResponse, error) {
+func (c *Client) CreateIamTrustRole(options *CreateIamRoleOptions) (*IamRoleResponse, error) {
 	request, err := NewIamRoleRequest(options)
 
 	b, err := json.Marshal(struct {

--- a/iam_role.go
+++ b/iam_role.go
@@ -251,18 +251,18 @@ func (c *Client) CreateIamTrustRole(options *CreateIamRoleOptions) (*IamRoleResp
 
 type UpdateRoleRequest struct {
 	RoleName *string `json:"roleName"`
-	Tags     *[]Tag  `json:"tags,omitempty"`
+	Tags     *[]Tag  `json:"tags"`
 }
 
 type UpdateRoleResponse struct {
 	BaseResponse
-	RoleArn         *string `json:"roleArn,omitempty"`
+	RoleArn         *string `json:"roleArn"`
 	RoleName        *string `json:"roleName"`
-	BasicAuth       *bool   `json:"basicAuthUsed,omitempty"`
-	Exists          *bool   `json:"roleExists,omitempty"`
-	RoleIPArn       *string `json:"instanceProfileArn,omitempty"`
-	MachineIdentity *bool   `json:"isMachineIdentity,omitempty"`
-	Tags            *[]Tag  `json:"tags,omitempty"`
+	BasicAuth       *bool   `json:"basicAuthUsed"`
+	Exists          *bool   `json:"roleExists"`
+	RoleIPArn       *string `json:"instanceProfileArn"`
+	MachineIdentity *bool   `json:"isMachineIdentity"`
+	Tags            *[]Tag  `json:"tags"`
 }
 
 type requestOp struct {
@@ -289,11 +289,6 @@ func (c *Client) makeIamRoleRequest(op *requestOp) error {
 		}
 		return fmt.Errorf("error parsing %s response: %s", op.Operation, e)
 	}
-	base := op.Response.(*BaseResponse)
-	if base.RequestFailed() {
-		return fmt.Errorf("error from %s: [%s] %s", op.Operation, base.RequestID, strings.Join(base.GetErrors(), ", "))
-	}
-
 	return nil
 }
 
@@ -312,21 +307,22 @@ func (c *Client) UpdateIamRole(req *UpdateRoleRequest) (*UpdateRoleResponse, err
 	if e != nil {
 		return nil, e
 	}
-
+	resp := &UpdateRoleResponse{}
 	op := &requestOp{
 		Operation: "update IAM role",
 		ReqObj:    b,
 		Method:    "PATCH",
 		Endpoint:  "/role/",
-		Response:  &UpdateRoleResponse{},
+		Response:  resp,
 	}
 	if e := c.makeIamRoleRequest(op); e != nil {
 		return nil, e
 	}
+	if resp.RequestFailed() {
+		return nil, fmt.Errorf("error from update IAM role request: [%s] %s", resp.RequestID, strings.Join(resp.GetErrors(), ", "))
+	}
 
-	resp := op.Response.(UpdateRoleResponse)
-
-	return &resp, nil
+	return resp, nil
 }
 
 func (req *UpdateRoleRequest) updateIamRoleValidate() error {

--- a/iam_role.go
+++ b/iam_role.go
@@ -273,6 +273,11 @@ type IamRoleOutput struct {
 	Tags                        *[]Tag             `json:"tags,omitempty"`
 }
 
+type encoder struct {
+	*AccountDetails
+	*IamRoleInput
+}
+
 type requestOp struct {
 	ReqObj   []byte
 	Method   string
@@ -280,11 +285,8 @@ type requestOp struct {
 	Response *IamRoleOutput
 }
 
-func (input *IamRoleInput) marshalJSON(c *Client) ([]byte, error) {
-	obj, e := json.Marshal(struct {
-		IamRoleInput
-		AccountDetails
-	}{*input, c.AccountDetails})
+func (enc *encoder) MarshalJSON() ([]byte, error) {
+	obj, e := json.Marshal(*enc)
 	if e != nil {
 		return nil, e
 	}
@@ -325,7 +327,8 @@ func (c *Client) UpdateIamRole(options func(*IamRoleInput)) (*IamRoleOutput, err
 		return nil, e
 	}
 
-	obj, e := input.marshalJSON(c)
+	encodeObj := &encoder{IamRoleInput: input, AccountDetails: &c.AccountDetails}
+	obj, e := json.Marshal(encodeObj)
 	if e != nil {
 		return nil, e
 	}

--- a/iam_role.go
+++ b/iam_role.go
@@ -340,8 +340,8 @@ func (c *Client) UpdateIamRole(options func(*IamRoleInput)) (*IamRoleOutput, err
 
 	req := &requestOp{
 		ReqObj:   obj,
-		Method:   "POST",
-		Endpoint: "/updateRole/",
+		Method:   "PATCH",
+		Endpoint: "/role/",
 		Response: &IamRoleOutput{},
 	}
 	if e := c.makeIamRoleRequest(req); e != nil {

--- a/iam_role.go
+++ b/iam_role.go
@@ -249,33 +249,20 @@ func (c *Client) CreateIamTrustRole(options *CreateIamRoleOptions) (*IamRoleResp
 	return cr, nil
 }
 
-type IamRoleInput struct {
-	RoleName                    *string            `json:"roleName"`
-	RoleType                    *string            `json:"roleType,omitempty"`
-	IncDefPols                  *int               `json:"includeDefaultPolicy,omitempty"`
-	AlksAccess                  *bool              `json:"enableAlksAccess,omitempty"`
-	TrustArn                    *string            `json:"trustArn,omitempty"`
-	TemplateFields              *map[string]string `json:"templateFields,omitempty"`
-	MaxSessionDurationInSeconds *int               `json:"maxSessionDurationInSeconds,omitempty"`
-	Tags                        *[]Tag             `json:"tags,omitempty"`
+type UpdateRoleRequest struct {
+	RoleName *string `json:"roleName"`
+	Tags     *[]Tag  `json:"tags,omitempty"`
 }
 
-type IamRoleOutput struct {
+type UpdateRoleResponse struct {
 	BaseResponse
-	RoleName                    *string            `json:"roleName"`
-	RoleType                    *string            `json:"roleType,omitempty"`
-	RoleArn                     *string            `json:"roleArn,omitempty"`
-	RoleIPArn                   *string            `json:"instanceProfileArn,omitempty"`
-	RoleAddedToIP               *bool              `json:"addedRoleToInstanceProfile,omitempty"`
-	Exists                      *bool              `json:"roleExists,omitempty"`
-	TemplateFields              *map[string]string `json:"templateFields,omitempty"`
-	MaxSessionDurationInSeconds *int               `json:"maxSessionDurationInSeconds,omitempty"`
-	Tags                        *[]Tag             `json:"tags,omitempty"`
-}
-
-type encodeDetails struct {
-	*AccountDetails
-	*IamRoleInput
+	RoleArn         *string `json:"roleArn,omitempty"`
+	RoleName        *string `json:"roleName"`
+	BasicAuth       *bool   `json:"basicAuthUsed,omitempty"`
+	Exists          *bool   `json:"roleExists,omitempty"`
+	RoleIPArn       *string `json:"instanceProfileArn,omitempty"`
+	MachineIdentity *bool   `json:"isMachineIdentity,omitempty"`
+	Tags            *[]Tag  `json:"tags,omitempty"`
 }
 
 type requestOp struct {

--- a/iam_role.go
+++ b/iam_role.go
@@ -149,18 +149,18 @@ func NewIamRoleRequest(options *CreateIamRoleOptions) (*IamRoleRequest, error) {
 // CreateIamRole will create a new IAM role in AWS. If no error is returned
 // then you will receive a IamRoleResponse object representing the new role.
 func (c *Client) CreateIamRole(options *CreateIamRoleOptions) (*IamRoleResponse, error) {
-	iam, err := NewIamRoleRequest(options)
+	request, err := NewIamRoleRequest(options)
 
 	if err != nil {
 		return nil, err
 	}
 
-	log.Printf("[INFO] Creating IAM role: %s", iam.RoleName)
+	log.Printf("[INFO] Creating IAM role: %s", request.RoleName)
 
 	b, err := json.Marshal(struct {
 		IamRoleRequest
 		AccountDetails
-	}{*iam, c.AccountDetails})
+	}{*request, c.AccountDetails})
 
 	if err != nil {
 		return nil, fmt.Errorf("Error encoding IAM create role JSON: %s", err)
@@ -197,12 +197,12 @@ func (c *Client) CreateIamRole(options *CreateIamRoleOptions) (*IamRoleResponse,
 // CreateIamTrustRole will create a new IAM trust role on AWS. If no error is returned
 // then you will receive a IamRoleResponse object representing the new role.
 func (c *Client) CreateIamTrustRole(options *CreateIamRoleOptions) (*IamRoleResponse, error) {
-	iam, err := NewIamRoleRequest(options)
+	request, err := NewIamRoleRequest(options)
 
 	b, err := json.Marshal(struct {
 		IamRoleRequest
 		AccountDetails
-	}{*iam, c.AccountDetails})
+	}{*request, c.AccountDetails})
 
 	if err != nil {
 		return nil, fmt.Errorf("Error encoding IAM create trust role JSON: %s", err)

--- a/iam_role.go
+++ b/iam_role.go
@@ -273,7 +273,7 @@ type IamRoleOutput struct {
 	Tags                        *[]Tag             `json:"tags,omitempty"`
 }
 
-type encoder struct {
+type encodeDetails struct {
 	*AccountDetails
 	*IamRoleInput
 }
@@ -285,7 +285,7 @@ type requestOp struct {
 	Response *IamRoleOutput
 }
 
-func (enc *encoder) MarshalJSON() ([]byte, error) {
+func (enc *encodeDetails) MarshalJSON() ([]byte, error) {
 	obj, e := json.Marshal(*enc)
 	if e != nil {
 		return nil, e
@@ -327,7 +327,7 @@ func (c *Client) UpdateIamRole(options func(*IamRoleInput)) (*IamRoleOutput, err
 		return nil, e
 	}
 
-	encodeObj := &encoder{IamRoleInput: input, AccountDetails: &c.AccountDetails}
+	encodeObj := &encodeDetails{IamRoleInput: input, AccountDetails: &c.AccountDetails}
 	obj, e := json.Marshal(encodeObj)
 	if e != nil {
 		return nil, e

--- a/iam_role.go
+++ b/iam_role.go
@@ -330,14 +330,13 @@ func (c *Client) UpdateIamRole(options func(*IamRoleInput)) (*IamRoleOutput, err
 	if e := input.updateIamRoleValidate(options); e != nil {
 		return nil, e
 	}
+	log.Printf("[INFO] update IAM role %s with Tags: %v", *input.RoleName, *input.Tags)
 
 	encodeObj := &encodeDetails{IamRoleInput: input, AccountDetails: &c.AccountDetails}
 	obj, e := json.Marshal(encodeObj)
 	if e != nil {
 		return nil, e
 	}
-
-	log.Printf("[INFO] Updating IAM role %s with Tags: %v", *(input.RoleName), input.Tags)
 
 	op := &requestOp{
 		Operation: "update IAM role",
@@ -353,17 +352,17 @@ func (c *Client) UpdateIamRole(options func(*IamRoleInput)) (*IamRoleOutput, err
 	return op.Response, nil
 }
 
-func (updateRoleInput *IamRoleInput) updateIamRoleValidate(options ...func(*IamRoleInput)) (err error) {
+func (input *IamRoleInput) updateIamRoleValidate(options ...func(*IamRoleInput)) error {
 	for _, f := range options {
-		f(updateRoleInput)
+		f(input)
 	}
-	if updateRoleInput.RoleName == nil {
-		err = fmt.Errorf("roleName option must not be nil")
+	if input.RoleName == nil {
+		return fmt.Errorf("roleName option must not be nil")
 	}
-	if updateRoleInput.Tags == nil {
-		err = fmt.Errorf("tags option must not be nil")
+	if input.Tags == nil {
+		return fmt.Errorf("tags option must not be nil")
 	}
-	return
+	return nil
 }
 
 // DeleteIamRole will delete an existing IAM role from AWS. If no error is returned

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -181,7 +181,7 @@ func (s *S) Test_UpdateIamRole(c *C) {
 			Value: "161803",
 		},
 	}
-	opts := &CreateIamRoleOptions{
+	opts := &UpdateRoleInput{
 		RoleName: &roleName,
 		Tags:     &tags,
 	}

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -185,15 +185,14 @@ func (s *S) Test_UpdateIamRole(c *C) {
 	resp, err := s.client.UpdateIamRole(func(opts *IamRoleInput) {
 		opts.RoleName = &roleName
 		opts.Tags = &tags
-
 	})
 
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
 	c.Assert(resp, NotNil)
-	c.Assert(resp.RoleName, Equals, "rolebae")
-	c.Assert(resp.RoleType, Equals, "Amazon EC2")
+	c.Assert(*resp.RoleName, Equals, "rolebae")
+	c.Assert(*resp.RoleType, Equals, "Amazon EC2")
 }
 
 func (s *S) Test_DeleteIamRole(c *C) {

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -9,7 +9,7 @@ func (s *S) Test_CreateIamRole(c *C) {
 
 	roleName := "rolebae"
 	roleType := "Amazon EC2"
-	opts := &CreateIamRoleOptions{
+	opts := &IamRoleOptions{
 		RoleName: &roleName,
 		RoleType: &roleType,
 	}
@@ -34,7 +34,7 @@ func (s *S) Test_CreateIamRoleTemplateFields(c *C) {
 		"A": "B",
 		"C": "D",
 	}
-	opts := &CreateIamRoleOptions{
+	opts := &IamRoleOptions{
 		RoleName:       &roleName,
 		RoleType:       &roleType,
 		TemplateFields: &templateFields,
@@ -63,7 +63,7 @@ func (s *S) Test_CreateIamRoleOptions(c *C) {
 		"C": "D",
 	}
 	maxSessionDuration := 7200
-	opts := &CreateIamRoleOptions{
+	opts := &IamRoleOptions{
 		RoleName:                    &roleName,
 		RoleType:                    &roleType,
 		TemplateFields:              &templateFields,
@@ -99,7 +99,7 @@ func (s *S) Test_CreateIamRoleWithTags(c *C) {
 		},
 	}
 
-	opts := &CreateIamRoleOptions{
+	opts := &IamRoleOptions{
 		RoleName: &roleName,
 		RoleType: &roleType,
 		Tags:     &tags,
@@ -125,7 +125,7 @@ func (s *S) Test_CreateIamTrustRole(c *C) {
 		"A": "B",
 		"C": "D",
 	}
-	opts := &CreateIamRoleOptions{
+	opts := &IamRoleOptions{
 		RoleName:       &roleName,
 		RoleType:       &roleType,
 		TrustArn:       &roleTrust,
@@ -165,6 +165,35 @@ func (s *S) Test_GetIamRoleMissing(c *C) {
 	_ = testServer.WaitRequest()
 
 	c.Assert(resp, IsNil)
+}
+
+func (s *S) Test_UpdateIamRole(c *C) {
+	testServer.Response(202, nil, iamGetRole)
+
+	roleName := "rolebae"
+	tags := []Tag{
+		{
+			Key:   "cai-owner",
+			Value: "123456",
+		},
+		{
+			Key:   "cai-person",
+			Value: "161803",
+		},
+	}
+	opts := &IamRoleOptions{
+		RoleName: &roleName,
+		Tags:     &tags,
+	}
+
+	resp, err := s.client.UpdateIamRole(opts)
+
+	_ = testServer.WaitRequest()
+
+	c.Assert(err, IsNil)
+	c.Assert(resp, NotNil)
+	c.Assert(resp.RoleName, Equals, "rolebae")
+	c.Assert(resp.RoleType, Equals, "Amazon EC2")
 }
 
 func (s *S) Test_DeleteIamRole(c *C) {

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -86,7 +86,21 @@ func (s *S) Test_CreateIamRoleOptions(c *C) {
 func (s *S) Test_CreateIamTrustRole(c *C) {
 	testServer.Response(202, nil, iamGetTrustRole)
 
-	resp, err := s.client.CreateIamTrustRole("test-cross-role", "Cross Account", "arn:aws:iam::123456789123:role/test-role", false)
+	roleName := "test-cross-role"
+	roleType := "Cross Account"
+	roleTrust := "arn:aws:iam::123456789123:role/test-role"
+	templateFields := map[string]string{
+		"A": "B",
+		"C": "D",
+	}
+	opts := &CreateIamRoleOptions{
+		RoleName:       &roleName,
+		RoleType:       &roleType,
+		TrustArn:       &roleTrust,
+		TemplateFields: &templateFields,
+	}
+
+	resp, err := s.client.CreateIamTrustRole(opts)
 
 	_ = testServer.WaitRequest()
 

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -168,9 +168,9 @@ func (s *S) Test_GetIamRoleMissing(c *C) {
 }
 
 func (s *S) Test_UpdateIamRole(c *C) {
-	testServer.Response(202, nil, iamGetRole)
+	testServer.Response(202, nil, updateRoleResponse)
 
-	roleName := "rolebae"
+	roleName := "test-update-role"
 	tags := []Tag{
 		{
 			Key:   "cai-owner",
@@ -181,18 +181,15 @@ func (s *S) Test_UpdateIamRole(c *C) {
 			Value: "161803",
 		},
 	}
-
-	resp, err := s.client.UpdateIamRole(func(opts *IamRoleInput) {
-		opts.RoleName = &roleName
-		opts.Tags = &tags
-	})
+	req := &UpdateRoleRequest{RoleName: &roleName, Tags: &tags}
+	resp, err := s.client.UpdateIamRole(req)
 
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
 	c.Assert(resp, NotNil)
-	c.Assert(*resp.RoleName, Equals, "rolebae")
-	c.Assert(*resp.RoleType, Equals, "Amazon EC2")
+	c.Assert(*resp.RoleName, Equals, "test-update-role")
+	c.Assert(*resp.Tags, NotNil)
 }
 
 func (s *S) Test_DeleteIamRole(c *C) {
@@ -314,5 +311,18 @@ var iamGetRole404 = `
 var machineIdentityResponse = `
 {
 	"machineIdentityArn": "arn:aws:iam::123456789123:role/acct-managed/test123"
+}
+`
+
+var updateRoleResponse = `
+{
+	"roleArn": "aws:arn:foo",
+	"roleName": "test-update-role",
+	"basicAuthUsed": false,
+	"roleExists": true,
+	"instanceProfileArn": "aws:arn:foo:ip",
+	"isMachineIdentity": true,
+	"tags": [{"key":"cai-owner","value":"123456"},{"key":"cai-person","value":"161803"}],
+	"errors": []
 }
 `

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -83,6 +83,38 @@ func (s *S) Test_CreateIamRoleOptions(c *C) {
 	c.Assert(resp.MaxSessionDurationInSeconds, Equals, 7200)
 }
 
+func (s *S) Test_CreateIamRoleWithTags(c *C) {
+	testServer.Response(202, nil, iamGetRoleOptions)
+
+	roleName := "rolebae"
+	roleType := "Amazon EC2"
+	tags := []Tag{
+		{
+			Key:   "cai-owner",
+			Value: "123456",
+		},
+		{
+			Key:   "cai-person",
+			Value: "161803",
+		},
+	}
+
+	opts := &CreateIamRoleOptions{
+		RoleName: &roleName,
+		RoleType: &roleType,
+		Tags:     &tags,
+	}
+
+	resp, err := s.client.CreateIamRole(opts)
+
+	_ = testServer.WaitRequest()
+
+	c.Assert(err, IsNil)
+	c.Assert(resp, NotNil)
+	c.Assert(resp.RoleName, Equals, "rolebae")
+	c.Assert(resp.RoleType, Equals, "Amazon EC2")
+}
+
 func (s *S) Test_CreateIamTrustRole(c *C) {
 	testServer.Response(202, nil, iamGetTrustRole)
 

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -9,7 +9,7 @@ func (s *S) Test_CreateIamRole(c *C) {
 
 	roleName := "rolebae"
 	roleType := "Amazon EC2"
-	opts := &IamRoleOptions{
+	opts := &CreateIamRoleOptions{
 		RoleName: &roleName,
 		RoleType: &roleType,
 	}
@@ -34,7 +34,7 @@ func (s *S) Test_CreateIamRoleTemplateFields(c *C) {
 		"A": "B",
 		"C": "D",
 	}
-	opts := &IamRoleOptions{
+	opts := &CreateIamRoleOptions{
 		RoleName:       &roleName,
 		RoleType:       &roleType,
 		TemplateFields: &templateFields,
@@ -63,7 +63,7 @@ func (s *S) Test_CreateIamRoleOptions(c *C) {
 		"C": "D",
 	}
 	maxSessionDuration := 7200
-	opts := &IamRoleOptions{
+	opts := &CreateIamRoleOptions{
 		RoleName:                    &roleName,
 		RoleType:                    &roleType,
 		TemplateFields:              &templateFields,
@@ -99,7 +99,7 @@ func (s *S) Test_CreateIamRoleWithTags(c *C) {
 		},
 	}
 
-	opts := &IamRoleOptions{
+	opts := &CreateIamRoleOptions{
 		RoleName: &roleName,
 		RoleType: &roleType,
 		Tags:     &tags,
@@ -125,7 +125,7 @@ func (s *S) Test_CreateIamTrustRole(c *C) {
 		"A": "B",
 		"C": "D",
 	}
-	opts := &IamRoleOptions{
+	opts := &CreateIamRoleOptions{
 		RoleName:       &roleName,
 		RoleType:       &roleType,
 		TrustArn:       &roleTrust,
@@ -181,7 +181,7 @@ func (s *S) Test_UpdateIamRole(c *C) {
 			Value: "161803",
 		},
 	}
-	opts := &IamRoleOptions{
+	opts := &CreateIamRoleOptions{
 		RoleName: &roleName,
 		Tags:     &tags,
 	}

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -7,32 +7,47 @@ import (
 func (s *S) Test_CreateIamRole(c *C) {
 	testServer.Response(202, nil, iamGetRole)
 
-	resp, err := s.client.CreateIamRole("rolebae", "Admin", nil, false, false)
+	roleName := "rolebae"
+	roleType := "Amazon EC2"
+	opts := &CreateIamRoleOptions{
+		RoleName: &roleName,
+		RoleType: &roleType,
+	}
+
+	resp, err := s.client.CreateIamRole(opts)
 
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
 	c.Assert(resp, NotNil)
 	c.Assert(resp.RoleName, Equals, "rolebae")
-	c.Assert(resp.RoleType, Equals, "Admin")
+	c.Assert(resp.RoleType, Equals, "Amazon EC2")
 	c.Assert(resp.MaxSessionDurationInSeconds, Equals, 3600)
 }
 
 func (s *S) Test_CreateIamRoleTemplateFields(c *C) {
 	testServer.Response(202, nil, iamGetRoleTemplateFields)
 
+	roleName := "rolebae"
+	roleType := "Amazon EC2"
 	templateFields := map[string]string{
 		"A": "B",
 		"C": "D",
 	}
-	resp, err := s.client.CreateIamRole("rolebae", "Admin", templateFields, false, false)
+	opts := &CreateIamRoleOptions{
+		RoleName:       &roleName,
+		RoleType:       &roleType,
+		TemplateFields: &templateFields,
+	}
+
+	resp, err := s.client.CreateIamRole(opts)
 
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
 	c.Assert(resp, NotNil)
 	c.Assert(resp.RoleName, Equals, "rolebae")
-	c.Assert(resp.RoleType, Equals, "Admin")
+	c.Assert(resp.RoleType, Equals, "Amazon EC2")
 	c.Assert(resp.TemplateFields["A"], Equals, templateFields["A"])
 	c.Assert(resp.TemplateFields["C"], Equals, templateFields["C"])
 	c.Assert(resp.MaxSessionDurationInSeconds, Equals, 3600)
@@ -41,21 +56,28 @@ func (s *S) Test_CreateIamRoleTemplateFields(c *C) {
 func (s *S) Test_CreateIamRoleOptions(c *C) {
 	testServer.Response(202, nil, iamGetRoleOptions)
 
+	roleName := "rolebae"
+	roleType := "Amazon EC2"
 	templateFields := map[string]string{
 		"A": "B",
 		"C": "D",
 	}
+	maxSessionDuration := 7200
+	opts := &CreateIamRoleOptions{
+		RoleName:                    &roleName,
+		RoleType:                    &roleType,
+		TemplateFields:              &templateFields,
+		MaxSessionDurationInSeconds: &maxSessionDuration,
+	}
 
-	options := CreateIamRoleOptions{0, false, templateFields, 7200}
-
-	resp, err := s.client.CreateIamRoleWithOptions("rolebae", "Admin", options)
+	resp, err := s.client.CreateIamRole(opts)
 
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
 	c.Assert(resp, NotNil)
 	c.Assert(resp.RoleName, Equals, "rolebae")
-	c.Assert(resp.RoleType, Equals, "Admin")
+	c.Assert(resp.RoleType, Equals, "Amazon EC2")
 	c.Assert(resp.TemplateFields["A"], Equals, templateFields["A"])
 	c.Assert(resp.TemplateFields["C"], Equals, templateFields["C"])
 	c.Assert(resp.MaxSessionDurationInSeconds, Equals, 7200)
@@ -84,7 +106,7 @@ func (s *S) Test_GetIamRole(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(resp, NotNil)
 	c.Assert(resp.RoleName, Equals, "rolebae")
-	c.Assert(resp.RoleType, Equals, "Admin")
+	c.Assert(resp.RoleType, Equals, "Amazon EC2")
 	c.Assert(resp.Exists, Equals, true)
 	c.Assert(resp.AlksAccess, NotNil)
 }
@@ -145,7 +167,7 @@ func (s *S) Test_SearchRoleMachineIdentity(c *C) {
 var iamGetRole = `
 {
     "roleName": "rolebae",
-    "roleType": "Admin",
+    "roleType": "Amazon EC2",
     "roleArn": "aws:arn:foo",
     "instanceProfileArn": "aws:arn:foo:ip",
     "addedRoleToInstanceProfile": true,
@@ -159,7 +181,7 @@ var iamGetRole = `
 var iamGetRoleTemplateFields = `
 {
     "roleName": "rolebae",
-    "roleType": "Admin",
+    "roleType": "Amazon EC2",
     "roleArn": "aws:arn:foo",
     "instanceProfileArn": "aws:arn:foo:ip",
     "addedRoleToInstanceProfile": true,
@@ -177,7 +199,7 @@ var iamGetRoleTemplateFields = `
 var iamGetRoleOptions = `
 {
     "roleName": "rolebae",
-    "roleType": "Admin",
+    "roleType": "Amazon EC2",
     "roleArn": "aws:arn:foo",
     "instanceProfileArn": "aws:arn:foo:ip",
     "addedRoleToInstanceProfile": true,

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -181,12 +181,12 @@ func (s *S) Test_UpdateIamRole(c *C) {
 			Value: "161803",
 		},
 	}
-	opts := &UpdateRoleInput{
-		RoleName: &roleName,
-		Tags:     &tags,
-	}
 
-	resp, err := s.client.UpdateIamRole(opts)
+	resp, err := s.client.UpdateIamRole(func(opts *IamRoleInput) {
+		opts.RoleName = &roleName
+		opts.Tags = &tags
+
+	})
 
 	_ = testServer.WaitRequest()
 

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -181,7 +181,7 @@ func (s *S) Test_UpdateIamRole(c *C) {
 			Value: "161803",
 		},
 	}
-	req := &UpdateRoleRequest{RoleName: &roleName, Tags: &tags}
+	req := &UpdateIamRoleRequest{RoleName: &roleName, Tags: &tags}
 	resp, err := s.client.UpdateIamRole(req)
 
 	_ = testServer.WaitRequest()


### PR DESCRIPTION
## Description
Adds support for AWS resource tagging on createRole and createTrustRole functions and refactors the same functions to use an optional parameters struct.

## Note
Wait to merge until this functionality is added to ALKS core

### Rally # [US808571](https://rally1.rallydev.com/#/?detail=/userstory/631620981185&fdp=true): ALKS Go - Add Tag Field to Create Role