### PR TITLE
Update role

### DIFF
--- a/iam_role.go
+++ b/iam_role.go
@@ -276,7 +276,7 @@ func updateOptions(o *IamRoleOptions) (options *IamRoleRequest, err error) {
 }
 
 // UpdateIamRole adds resource tags to an existing IAM role.
-func (c *Client) UpdateIamRole(options *IamRoleOptions) error {
+func (c *Client) UpdateIamRole(options *IamRoleOptions) (*IamRoleResponse, error) {
 	requestOptions, _ := updateOptions(options)
 	log.Printf("[INFO] Updating IAM role %s with Tags: %v", requestOptions.RoleName, requestOptions.Tags)
 
@@ -286,26 +286,26 @@ func (c *Client) UpdateIamRole(options *IamRoleOptions) error {
 
 	req, err := c.NewRequest(b, "POST", "/updateRole/")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	respObj := new(IamRoleResponse)
 	err = decodeBody(resp, &respObj)
 
 	if err != nil {
 		if reqID := GetRequestID(resp); reqID != "" {
-			return fmt.Errorf("Error parsing updateRole response: [%s] %s", reqID, err)
+			return nil, fmt.Errorf("Error parsing updateRole response: [%s] %s", reqID, err)
 		}
-		return fmt.Errorf("Error parsing updateRole response: %s", err)
+		return nil, fmt.Errorf("Error parsing updateRole response: %s", err)
 	}
 	if respObj.RequestFailed() {
-		return fmt.Errorf("Error updating role: [%s] %s", respObj.BaseResponse.RequestID, strings.Join(respObj.GetErrors(), ", "))
+		return nil, fmt.Errorf("Error updating role: [%s] %s", respObj.BaseResponse.RequestID, strings.Join(respObj.GetErrors(), ", "))
 	}
 
-	return nil
+	return respObj, nil
 }
 
 // DeleteIamRole will delete an existing IAM role from AWS. If no error is returned

--- a/iam_role.go
+++ b/iam_role.go
@@ -309,6 +309,9 @@ func (c *Client) makeIamRoleRequest(operation *requestOp) error {
 		}
 		return fmt.Errorf("error parsing updateRole response: %s", e)
 	}
+	if operation.Response.RequestFailed() {
+		return fmt.Errorf("error updating role: [%s] %s", *operation.Response.RoleName, strings.Join(operation.Response.GetErrors(), ", "))
+	}
 
 	return nil
 }
@@ -343,9 +346,6 @@ func (c *Client) UpdateIamRole(options func(*IamRoleInput)) (*IamRoleOutput, err
 	}
 	if e := c.makeIamRoleRequest(req); e != nil {
 		return nil, e
-	}
-	if req.Response.RequestFailed() {
-		return nil, fmt.Errorf("error updating role: [%s] %s", *input.RoleName, strings.Join(req.Response.GetErrors(), ", "))
 	}
 
 	return req.Response, nil

--- a/iam_role.go
+++ b/iam_role.go
@@ -13,7 +13,7 @@ type Tag struct {
 	Value string `json:"value"`
 }
 
-type IamRoleOptions struct {
+type CreateIamRoleOptions struct {
 	RoleName                    *string
 	RoleType                    *string
 	IncludeDefaultPolicies      *bool
@@ -27,13 +27,13 @@ type IamRoleOptions struct {
 // IamRoleRequest is used to represent a new IAM Role request.
 type IamRoleRequest struct {
 	RoleName                    string            `json:"roleName"`
-	RoleType                    string            `json:"roleType,omitempty"`
-	IncDefPols                  int               `json:"includeDefaultPolicy,omitempty"`
-	AlksAccess                  bool              `json:"enableAlksAccess.omitempty"`
+	RoleType                    string            `json:"roleType"`
+	IncDefPols                  int               `json:"includeDefaultPolicy"`
+	AlksAccess                  bool              `json:"enableAlksAccess"`
 	TrustArn                    string            `json:"trustArn,omitempty"`
 	TemplateFields              map[string]string `json:"templateFields,omitempty"`
-	MaxSessionDurationInSeconds int               `json:"maxSessionDurationInSeconds,omitempty"`
-	Tags                        []Tag             `json:"tags,omitempty"`
+	MaxSessionDurationInSeconds int               `json:"maxSessionDurationInSeconds"`
+	Tags                        []Tag             `json:"tags"`
 }
 
 // IamRoleResponse is used to represent a a IAM Role.
@@ -107,7 +107,7 @@ type MachineIdentityResponse struct {
 }
 
 // Creates a new IamRoleRequest object from options
-func NewIamRoleRequest(options *IamRoleOptions) (*IamRoleRequest, error) {
+func NewIamRoleRequest(options *CreateIamRoleOptions) (*IamRoleRequest, error) {
 	if options.RoleName == nil {
 		return nil, fmt.Errorf("RoleName option must not be nil")
 	}
@@ -161,7 +161,7 @@ func NewIamRoleRequest(options *IamRoleOptions) (*IamRoleRequest, error) {
 
 // CreateIamRole will create a new IAM role in AWS. If no error is returned
 // then you will receive a IamRoleResponse object representing the new role.
-func (c *Client) CreateIamRole(options *IamRoleOptions) (*IamRoleResponse, error) {
+func (c *Client) CreateIamRole(options *CreateIamRoleOptions) (*IamRoleResponse, error) {
 	request, err := NewIamRoleRequest(options)
 
 	if err != nil {
@@ -209,7 +209,7 @@ func (c *Client) CreateIamRole(options *IamRoleOptions) (*IamRoleResponse, error
 
 // CreateIamTrustRole will create a new IAM trust role on AWS. If no error is returned
 // then you will receive a IamRoleResponse object representing the new role.
-func (c *Client) CreateIamTrustRole(options *IamRoleOptions) (*IamRoleResponse, error) {
+func (c *Client) CreateIamTrustRole(options *CreateIamRoleOptions) (*IamRoleResponse, error) {
 	request, err := NewIamRoleRequest(options)
 
 	b, err := json.Marshal(struct {

--- a/iam_role.go
+++ b/iam_role.go
@@ -273,6 +273,11 @@ type IamRoleOutput struct {
 	Tags                        *[]Tag             `json:"tags,omitempty"`
 }
 
+type encoder struct {
+	*AccountDetails
+	*IamRoleInput
+}
+
 type requestOp struct {
 	ReqObj   []byte
 	Method   string
@@ -280,11 +285,8 @@ type requestOp struct {
 	Response *IamRoleOutput
 }
 
-func (input *IamRoleInput) marshalJSON(c *Client) ([]byte, error) {
-	obj, e := json.Marshal(struct {
-		IamRoleInput
-		AccountDetails
-	}{*input, c.AccountDetails})
+func (enc *encoder) MarshalJSON() ([]byte, error) {
+	obj, e := json.Marshal(*enc)
 	if e != nil {
 		return nil, e
 	}
@@ -325,7 +327,8 @@ func (c *Client) UpdateIamRole(options func(*IamRoleInput)) (*IamRoleOutput, err
 		return nil, e
 	}
 
-	obj, e := input.marshalJSON(c)
+	encodeObj := &encoder{IamRoleInput: input, AccountDetails: &c.AccountDetails}
+	obj, e := json.Marshal(encodeObj)
 	if e != nil {
 		return nil, e
 	}

--- a/iam_role.go
+++ b/iam_role.go
@@ -273,7 +273,7 @@ type IamRoleOutput struct {
 	Tags                        *[]Tag             `json:"tags,omitempty"`
 }
 
-type encoder struct {
+type encodeDetails struct {
 	*AccountDetails
 	*IamRoleInput
 }
@@ -285,7 +285,7 @@ type requestOp struct {
 	Response *IamRoleOutput
 }
 
-func (enc *encoder) MarshalJSON() ([]byte, error) {
+func (enc *encodeDetails) MarshalJSON() ([]byte, error) {
 	obj, e := json.Marshal(*enc)
 	if e != nil {
 		return nil, e
@@ -327,7 +327,7 @@ func (c *Client) UpdateIamRole(options func(*IamRoleInput)) (*IamRoleOutput, err
 		return nil, e
 	}
 
-	encodeObj := &encoder{IamRoleInput: input, AccountDetails: &c.AccountDetails}
+	encodeObj := &encodeDetails{IamRoleInput: input, AccountDetails: &c.AccountDetails}
 	obj, e := json.Marshal(encodeObj)
 	if e != nil {
 		return nil, e

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -181,7 +181,7 @@ func (s *S) Test_UpdateIamRole(c *C) {
 			Value: "161803",
 		},
 	}
-	opts := &CreateIamRoleOptions{
+	opts := &UpdateRoleInput{
 		RoleName: &roleName,
 		Tags:     &tags,
 	}

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -185,15 +185,14 @@ func (s *S) Test_UpdateIamRole(c *C) {
 	resp, err := s.client.UpdateIamRole(func(opts *IamRoleInput) {
 		opts.RoleName = &roleName
 		opts.Tags = &tags
-
 	})
 
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
 	c.Assert(resp, NotNil)
-	c.Assert(resp.RoleName, Equals, "rolebae")
-	c.Assert(resp.RoleType, Equals, "Amazon EC2")
+	c.Assert(*resp.RoleName, Equals, "rolebae")
+	c.Assert(*resp.RoleType, Equals, "Amazon EC2")
 }
 
 func (s *S) Test_DeleteIamRole(c *C) {

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -9,7 +9,7 @@ func (s *S) Test_CreateIamRole(c *C) {
 
 	roleName := "rolebae"
 	roleType := "Amazon EC2"
-	opts := &CreateIamRoleOptions{
+	opts := &IamRoleOptions{
 		RoleName: &roleName,
 		RoleType: &roleType,
 	}
@@ -34,7 +34,7 @@ func (s *S) Test_CreateIamRoleTemplateFields(c *C) {
 		"A": "B",
 		"C": "D",
 	}
-	opts := &CreateIamRoleOptions{
+	opts := &IamRoleOptions{
 		RoleName:       &roleName,
 		RoleType:       &roleType,
 		TemplateFields: &templateFields,
@@ -63,7 +63,7 @@ func (s *S) Test_CreateIamRoleOptions(c *C) {
 		"C": "D",
 	}
 	maxSessionDuration := 7200
-	opts := &CreateIamRoleOptions{
+	opts := &IamRoleOptions{
 		RoleName:                    &roleName,
 		RoleType:                    &roleType,
 		TemplateFields:              &templateFields,
@@ -99,7 +99,7 @@ func (s *S) Test_CreateIamRoleWithTags(c *C) {
 		},
 	}
 
-	opts := &CreateIamRoleOptions{
+	opts := &IamRoleOptions{
 		RoleName: &roleName,
 		RoleType: &roleType,
 		Tags:     &tags,
@@ -125,7 +125,7 @@ func (s *S) Test_CreateIamTrustRole(c *C) {
 		"A": "B",
 		"C": "D",
 	}
-	opts := &CreateIamRoleOptions{
+	opts := &IamRoleOptions{
 		RoleName:       &roleName,
 		RoleType:       &roleType,
 		TrustArn:       &roleTrust,
@@ -165,6 +165,35 @@ func (s *S) Test_GetIamRoleMissing(c *C) {
 	_ = testServer.WaitRequest()
 
 	c.Assert(resp, IsNil)
+}
+
+func (s *S) Test_UpdateIamRole(c *C) {
+	testServer.Response(202, nil, iamGetRole)
+
+	roleName := "rolebae"
+	tags := []Tag{
+		{
+			Key:   "cai-owner",
+			Value: "123456",
+		},
+		{
+			Key:   "cai-person",
+			Value: "161803",
+		},
+	}
+	opts := &IamRoleOptions{
+		RoleName: &roleName,
+		Tags:     &tags,
+	}
+
+	resp, err := s.client.UpdateIamRole(opts)
+
+	_ = testServer.WaitRequest()
+
+	c.Assert(err, IsNil)
+	c.Assert(resp, NotNil)
+	c.Assert(resp.RoleName, Equals, "rolebae")
+	c.Assert(resp.RoleType, Equals, "Amazon EC2")
 }
 
 func (s *S) Test_DeleteIamRole(c *C) {

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -9,7 +9,7 @@ func (s *S) Test_CreateIamRole(c *C) {
 
 	roleName := "rolebae"
 	roleType := "Amazon EC2"
-	opts := &IamRoleOptions{
+	opts := &CreateIamRoleOptions{
 		RoleName: &roleName,
 		RoleType: &roleType,
 	}
@@ -34,7 +34,7 @@ func (s *S) Test_CreateIamRoleTemplateFields(c *C) {
 		"A": "B",
 		"C": "D",
 	}
-	opts := &IamRoleOptions{
+	opts := &CreateIamRoleOptions{
 		RoleName:       &roleName,
 		RoleType:       &roleType,
 		TemplateFields: &templateFields,
@@ -63,7 +63,7 @@ func (s *S) Test_CreateIamRoleOptions(c *C) {
 		"C": "D",
 	}
 	maxSessionDuration := 7200
-	opts := &IamRoleOptions{
+	opts := &CreateIamRoleOptions{
 		RoleName:                    &roleName,
 		RoleType:                    &roleType,
 		TemplateFields:              &templateFields,
@@ -99,7 +99,7 @@ func (s *S) Test_CreateIamRoleWithTags(c *C) {
 		},
 	}
 
-	opts := &IamRoleOptions{
+	opts := &CreateIamRoleOptions{
 		RoleName: &roleName,
 		RoleType: &roleType,
 		Tags:     &tags,
@@ -125,7 +125,7 @@ func (s *S) Test_CreateIamTrustRole(c *C) {
 		"A": "B",
 		"C": "D",
 	}
-	opts := &IamRoleOptions{
+	opts := &CreateIamRoleOptions{
 		RoleName:       &roleName,
 		RoleType:       &roleType,
 		TrustArn:       &roleTrust,
@@ -181,7 +181,7 @@ func (s *S) Test_UpdateIamRole(c *C) {
 			Value: "161803",
 		},
 	}
-	opts := &IamRoleOptions{
+	opts := &CreateIamRoleOptions{
 		RoleName: &roleName,
 		Tags:     &tags,
 	}

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -181,12 +181,12 @@ func (s *S) Test_UpdateIamRole(c *C) {
 			Value: "161803",
 		},
 	}
-	opts := &UpdateRoleInput{
-		RoleName: &roleName,
-		Tags:     &tags,
-	}
 
-	resp, err := s.client.UpdateIamRole(opts)
+	resp, err := s.client.UpdateIamRole(func(opts *IamRoleInput) {
+		opts.RoleName = &roleName
+		opts.Tags = &tags
+
+	})
 
 	_ = testServer.WaitRequest()
 


### PR DESCRIPTION
Adds the update IAM role with tags functionality based on design changes made on the add-tags-to-create-role branch. 

Considerations:
* What struct should the end user be populating per request?
* Should we break out services and associated error handling into reusable pieces?
* Updating Go from 1.16 --> 1.18 for added generics support may help with the above consideration.
* Should updateRole return a json success message or nothing on success?

AWS structures their sdk like so:
```go
type UpdateRoleInput struct {
	_ struct{} `type:"structure"`
	Description *string `type:"string"`
	MaxSessionDuration *int64 `min:"3600" type:"integer"`
	RoleName *string `min:"1" type:"string" required:"true"`
}

func (s *UpdateRoleInput) Validate() error {
	invalidParams := request.ErrInvalidParams{Context: "UpdateRoleInput"}
	if s.MaxSessionDuration != nil && *s.MaxSessionDuration < 3600 {
		invalidParams.Add(request.NewErrParamMinValue("MaxSessionDuration", 3600))
	}
	if s.RoleName == nil {
		invalidParams.Add(request.NewErrParamRequired("RoleName"))
	}
	if s.RoleName != nil && len(*s.RoleName) < 1 {
		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
	}

	if invalidParams.Len() > 0 {
		return invalidParams
	}
	return nil
}


const opUpdateRole = "UpdateRole"

func (c *IAM) UpdateRoleRequest(input *UpdateRoleInput) (req *request.Request, output *UpdateRoleOutput) {
	op := &request.Operation{
		Name:       opUpdateRole,
		HTTPMethod: "POST",
		HTTPPath:   "/",
	}

	if input == nil {
		input = &UpdateRoleInput{}
	}

	output = &UpdateRoleOutput{}
	req = c.newRequest(op, input, output)
	req.Handlers.Unmarshal.Swap(query.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
	return
}


func (c *IAM) UpdateRole(input *UpdateRoleInput) (*UpdateRoleOutput, error) {
	req, out := c.UpdateRoleRequest(input)
	return out, req.Send()
}
```

