### PR TITLE
Add trust policy to createRole and getRole

### DIFF
--- a/iam_role.go
+++ b/iam_role.go
@@ -17,6 +17,7 @@ type Tag struct {
 type CreateIamRoleOptions struct {
 	RoleName                    *string
 	RoleType                    *string
+	TrustPolicy                 *map[string]interface{}
 	IncludeDefaultPolicies      *bool
 	AlksAccess                  *bool
 	TrustArn                    *string
@@ -27,40 +28,43 @@ type CreateIamRoleOptions struct {
 
 // IamRoleRequest is used to represent a new IAM Role request.
 type IamRoleRequest struct {
-	RoleName                    string            `json:"roleName"`
-	RoleType                    string            `json:"roleType,omitempty"`
-	IncDefPols                  int               `json:"includeDefaultPolicy,omitempty"`
-	AlksAccess                  bool              `json:"enableAlksAccess,omitempty"`
-	TrustArn                    string            `json:"trustArn,omitempty"`
-	TemplateFields              map[string]string `json:"templateFields,omitempty"`
-	MaxSessionDurationInSeconds int               `json:"maxSessionDurationInSeconds,omitempty"`
-	Tags                        []Tag             `json:"tags,omitempty"`
+	RoleName                    string                 `json:"roleName"`
+	RoleType                    string                 `json:"roleType,omitempty"`
+	TrustPolicy                 map[string]interface{} `json:"trustPolicy,omitempty"`
+	IncDefPols                  int                    `json:"includeDefaultPolicy,omitempty"`
+	AlksAccess                  bool                   `json:"enableAlksAccess,omitempty"`
+	TrustArn                    string                 `json:"trustArn,omitempty"`
+	TemplateFields              map[string]string      `json:"templateFields,omitempty"`
+	MaxSessionDurationInSeconds int                    `json:"maxSessionDurationInSeconds,omitempty"`
+	Tags                        []Tag                  `json:"tags,omitempty"`
 }
 
 // IamRoleResponse is used to represent a a IAM Role.
 type IamRoleResponse struct {
 	BaseResponse
-	RoleName                    string            `json:"roleName"`
-	RoleType                    string            `json:"roleType"`
-	RoleArn                     string            `json:"roleArn"`
-	RoleIPArn                   string            `json:"instanceProfileArn"`
-	RoleAddedToIP               bool              `json:"addedRoleToInstanceProfile"`
-	Exists                      bool              `json:"roleExists"`
-	TemplateFields              map[string]string `json:"templateFields,omitempty"`
-	MaxSessionDurationInSeconds int               `json:"maxSessionDurationInSeconds"`
+	RoleName                    string                 `json:"roleName"`
+	RoleType                    string                 `json:"roleType"`
+	TrustPolicy                 map[string]interface{} `json:"trustPolicy"`
+	RoleArn                     string                 `json:"roleArn"`
+	RoleIPArn                   string                 `json:"instanceProfileArn"`
+	RoleAddedToIP               bool                   `json:"addedRoleToInstanceProfile"`
+	Exists                      bool                   `json:"roleExists"`
+	TemplateFields              map[string]string      `json:"templateFields,omitempty"`
+	MaxSessionDurationInSeconds int                    `json:"maxSessionDurationInSeconds"`
 }
 
 // GetIamRoleResponse is used to represent a a IAM Role.
 type GetIamRoleResponse struct {
 	BaseResponse
-	RoleName      string `json:"roleName"`
-	RoleType      string `json:"roleType"`
-	RoleArn       string `json:"roleArn"`
-	RoleIPArn     string `json:"instanceProfileArn"`
-	RoleAddedToIP bool   `json:"addedRoleToInstanceProfile"`
-	Exists        bool   `json:"roleExists"`
-	AlksAccess    bool   `json:"machineIdentity"`
-	Tags          []Tag  `json:"tags"`
+	RoleName      string                 `json:"roleName"`
+	RoleType      string                 `json:"roleType"`
+	TrustPolicy   map[string]interface{} `json:"trustPolicy"`
+	RoleArn       string                 `json:"roleArn"`
+	RoleIPArn     string                 `json:"instanceProfileArn"`
+	RoleAddedToIP bool                   `json:"addedRoleToInstanceProfile"`
+	Exists        bool                   `json:"roleExists"`
+	AlksAccess    bool                   `json:"machineIdentity"`
+	Tags          []Tag                  `json:"tags"`
 }
 
 // GetRoleRequest is used to represent a request for details about
@@ -114,14 +118,26 @@ func NewIamRoleRequest(options *CreateIamRoleOptions) (*IamRoleRequest, error) {
 		return nil, fmt.Errorf("RoleName option must not be nil")
 	}
 
-	if options.RoleType == nil {
-		return nil, fmt.Errorf("RoleType option must not be nil")
+	if options.RoleType == nil && options.TrustPolicy == nil {
+		return nil, fmt.Errorf("Either RoleType or TrustPolicy option must not be nil")
+	}
+
+	if options.RoleType != nil && options.TrustPolicy != nil {
+		return nil, fmt.Errorf("RoleType and TrustPolicy options cannot be specified at the same time")
 	}
 
 	iam := &IamRoleRequest{
 		RoleName: *options.RoleName,
-		RoleType: *options.RoleType,
 	}
+
+	if options.RoleType != nil {
+		iam.RoleType = *options.RoleType
+	}
+
+	if options.TrustPolicy != nil {
+		iam.TrustPolicy = *options.TrustPolicy
+	}
+
 	if options.IncludeDefaultPolicies != nil && *options.IncludeDefaultPolicies {
 		iam.IncDefPols = 1
 	} else {

--- a/iam_role.go
+++ b/iam_role.go
@@ -123,7 +123,6 @@ func NewIamRoleRequest(options *CreateIamRoleOptions) (*IamRoleRequest, error) {
 	if trustPolicyExists == roleTypeExists {
 		return nil, fmt.Errorf("Either RoleType or TrustPolicy must be included, but not both")
 	}
-	}
 
 	iam := &IamRoleRequest{
 		RoleName: *options.RoleName,

--- a/iam_role.go
+++ b/iam_role.go
@@ -118,12 +118,11 @@ func NewIamRoleRequest(options *CreateIamRoleOptions) (*IamRoleRequest, error) {
 		return nil, fmt.Errorf("RoleName option must not be nil")
 	}
 
-	if options.RoleType == nil && options.TrustPolicy == nil {
-		return nil, fmt.Errorf("Either RoleType or TrustPolicy option must not be nil")
+	trustPolicyExists := options.TrustPolicy == nil
+	roleTypeExists := options.RoleType == nil
+	if trustPolicyExists == roleTypeExists {
+		return nil, fmt.Errorf("Either RoleType or TrustPolicy must be included, but not both")
 	}
-
-	if options.RoleType != nil && options.TrustPolicy != nil {
-		return nil, fmt.Errorf("RoleType and TrustPolicy options cannot be specified at the same time")
 	}
 
 	iam := &IamRoleRequest{


### PR DESCRIPTION
This PR adds an optional field for providing a trust policy when creating roles. If a trust policy is provided then a role type must not be provided and vice versa. 

Also included in this PR is returning the trustPolicy in the getRole endpoint response so that all information about a role is provided in one api call.

Unit test and simple input validation was added to test this functionality. 