### PR TITLE
Develop

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Rally # (issue / story / spike)
+
+## Type of change
+
+_Please remove options that are not relevant._
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation
+
+# How has this been tested?
+
+## Steps:
+  1. Step 1
+  2. Step 2
+  3. Step 3
+  4. etc...
+
+# Checklist / To Do:
+
+- [ ] Run Terraform non-prod
+- [ ] Run Terraform prod
+- [ ] Write documentation reflecting the change
+- [ ] Add param store value in non-prod
+- [ ] Add param store value in prod

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 
 # GoLand
 *.idea
+
+# Vscode
+.vscode

--- a/iam_role.go
+++ b/iam_role.go
@@ -56,15 +56,16 @@ type IamRoleResponse struct {
 // GetIamRoleResponse is used to represent a a IAM Role.
 type GetIamRoleResponse struct {
 	BaseResponse
-	RoleName      string                 `json:"roleName"`
-	RoleType      string                 `json:"roleType"`
-	TrustPolicy   map[string]interface{} `json:"trustPolicy"`
-	RoleArn       string                 `json:"roleArn"`
-	RoleIPArn     string                 `json:"instanceProfileArn"`
-	RoleAddedToIP bool                   `json:"addedRoleToInstanceProfile"`
-	Exists        bool                   `json:"roleExists"`
-	AlksAccess    bool                   `json:"machineIdentity"`
-	Tags          []Tag                  `json:"tags"`
+	RoleName                    string                 `json:"roleName"`
+	RoleType                    string                 `json:"roleType"`
+	TrustPolicy                 map[string]interface{} `json:"trustPolicy"`
+	RoleArn                     string                 `json:"roleArn"`
+	RoleIPArn                   string                 `json:"instanceProfileArn"`
+	RoleAddedToIP               bool                   `json:"addedRoleToInstanceProfile"`
+	Exists                      bool                   `json:"roleExists"`
+	AlksAccess                  bool                   `json:"machineIdentity"`
+	Tags                        []Tag                  `json:"tags"`
+	MaxSessionDurationInSeconds int                    `json:"maxSessionDurationInSeconds"`
 }
 
 // GetRoleRequest is used to represent a request for details about

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -225,6 +225,7 @@ func (s *S) Test_GetIamRole(c *C) {
 	c.Assert(resp.Tags[0].Value, Equals, "bar")
 	c.Assert(resp.Tags[1].Key, Equals, "cloud")
 	c.Assert(resp.Tags[1].Value, Equals, "railway")
+	c.Assert(resp.MaxSessionDurationInSeconds, Equals, 3600)
 }
 
 func (s *S) Test_GetIamRoleMissing(c *C) {


### PR DESCRIPTION
# Description

Passes MaxSessionDurationInSeconds from Alks getAccountRole endpoint through alks-go's getIAMRole function. 

Rally # [US896084](https://rally1.rallydev.com/#/?detail=/userstory/644634975005&fdp=true): ALKS Go: Return max_session_duration from getIAMRole

## Type of change

_Please remove options that are not relevant._

- [X] Feature (non-breaking change which adds functionality)

# How has this been tested?

## Steps:
  1. Unit Tests