### PR TITLE
Better error handling

### DIFF
--- a/iam_ltk.go
+++ b/iam_ltk.go
@@ -89,6 +89,32 @@ func (c *Client) GetLongTermKeys() (*GetLongTermKeysResponse, error) {
 		return nil, err
 	}
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		keyErr := new(AlksError)
+		err = decodeBody(resp, &keyErr)
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return nil, fmt.Errorf(ParseError, err)
+		}
+
+		if keyErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, keyErr.Errors)
+			}
+
+			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, keyErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
+	}
+
 	cr := new(GetLongTermKeysResponse)
 	err = decodeBody(resp, &cr)
 
@@ -140,6 +166,32 @@ func (c *Client) GetLongTermKey(iamUsername string) (*GetLongTermKeyResponse, er
 		return nil, err
 	}
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		keyErr := new(AlksError)
+		err = decodeBody(resp, &keyErr)
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return nil, fmt.Errorf(ParseError, err)
+		}
+
+		if keyErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, keyErr.Errors)
+			}
+
+			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, keyErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
+	}
+
 	cr := new(GetLongTermKeyResponse)
 	err = decodeBody(resp, &cr)
 
@@ -180,6 +232,32 @@ func (c *Client) CreateLongTermKey(iamUsername string) (*CreateLongTermKeyRespon
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		keyErr := new(AlksError)
+		err = decodeBody(resp, &keyErr)
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return nil, fmt.Errorf(ParseError, err)
+		}
+
+		if keyErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, keyErr.Errors)
+			}
+
+			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, keyErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	cr := new(CreateLongTermKeyResponse)
@@ -224,6 +302,32 @@ func (c *Client) DeleteLongTermKey(iamUsername string) (*DeleteLongTermKeyRespon
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		keyErr := new(AlksError)
+		err = decodeBody(resp, &keyErr)
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return nil, fmt.Errorf(ParseError, err)
+		}
+
+		if keyErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, keyErr.Errors)
+			}
+
+			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, keyErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	cr := new(DeleteLongTermKeyResponse)

--- a/iam_role.go
+++ b/iam_role.go
@@ -563,10 +563,6 @@ func (c *Client) GetIamRole(roleName string) (*GetIamRoleResponse, error) {
 		return nil, fmt.Errorf("Error getting role: [%s] %s", cr.BaseResponse.RequestID, strings.Join(cr.GetErrors(), ", "))
 	}
 
-	if !cr.Exists {
-		return nil, fmt.Errorf("[%s] Role does not exist", cr.BaseResponse.RequestID)
-	}
-
 	// This is here because ALKS returns a string representation of a Java array
 	// with the only entry being the instance profile ARN (ie: "[\"ARN\"]")
 	// A simple regex fixes the formatting issue and using existing instance

--- a/iam_role.go
+++ b/iam_role.go
@@ -14,6 +14,19 @@ type Tag struct {
 	Value string `json:"value"`
 }
 
+type AlksError struct {
+	StatusMessage string   `json:"statusMessage"`
+	Errors        []string `json:"errors"`
+	RequestId     string   `json:"requestId"`
+}
+
+var ErrorStringFull = "[%s] ALKS Error %d Msg: %s\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
+var ErrorStringNoReqId = "ALKS Error %d Msg: %s\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
+var ErrorStringOnlyCodeAndReqId = "[%s] ALKS Error %d\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
+var ErrorStringOnlyCode = "ALKS Error %d\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
+var ParseErrorReqId = "[%s] Error parsing ALKS Error response: %s"
+var ParseError = "Error parsing ALKS Error response: %s"
+
 type CreateIamRoleOptions struct {
 	RoleName                    *string
 	RoleType                    *string
@@ -205,6 +218,31 @@ func (c *Client) CreateIamRole(options *CreateIamRoleOptions) (*IamRoleResponse,
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		createErr := new(AlksError)
+		err = decodeBody(resp, &createErr)
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return nil, fmt.Errorf(ParseError, err)
+		}
+
+		if createErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, createErr.Errors)
+			}
+
+			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, createErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
+	}
 
 	cr := new(IamRoleResponse)
 	err = decodeBody(resp, &cr)
@@ -248,6 +286,33 @@ func (c *Client) CreateIamTrustRole(options *CreateIamRoleOptions) (*IamRoleResp
 		return nil, err
 	}
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		trustErr := new(AlksError)
+		err = decodeBody(resp, &trustErr)
+
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return nil, fmt.Errorf(ParseError, err)
+		}
+
+		if trustErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, trustErr.Errors)
+			}
+
+			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, trustErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
+	}
+
 	cr := new(IamRoleResponse)
 	err = decodeBody(resp, &cr)
 
@@ -285,33 +350,60 @@ type UpdateIamRoleResponse struct {
 /* UpdateIamRole adds resource tags to an existing IAM role.
  */
 func (c *Client) UpdateIamRole(options *UpdateIamRoleRequest) (*UpdateIamRoleResponse, error) {
-	if e := options.updateIamRoleValidate(); e != nil {
-		return nil, e
+	if err := options.updateIamRoleValidate(); err != nil {
+		return nil, err
 	}
 	log.Printf("[INFO] update IAM role %s with Tags: %v", *options.RoleName, *options.Tags)
 
-	b, e := json.Marshal(struct {
+	b, err := json.Marshal(struct {
 		UpdateIamRoleRequest
 		AccountDetails
 	}{*options, c.AccountDetails})
-	if e != nil {
-		return nil, e
+	if err != nil {
+		return nil, err
 	}
-	req, e := c.NewRequest(b, "PATCH", "/role/")
-	if e != nil {
-		return nil, e
+	req, err := c.NewRequest(b, "PATCH", "/role/")
+	if err != nil {
+		return nil, err
 	}
-	resp, e := c.http.Do(req)
-	if e != nil {
-		return nil, e
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		updateErr := new(AlksError)
+		err = decodeBody(resp, &updateErr)
+
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return nil, fmt.Errorf(ParseError, err)
+		}
+
+		if updateErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, updateErr.Errors)
+			}
+
+			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, updateErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	respObj := &UpdateIamRoleResponse{}
-	if e = decodeBody(resp, respObj); e != nil {
+	if err = decodeBody(resp, respObj); err != nil {
 		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf("error parsing update role response: [%s] %s", reqID, e)
+			return nil, fmt.Errorf("error parsing update role response: [%s] %s", reqID, err)
 		}
-		return nil, fmt.Errorf("error parsing update role response: %s", e)
+		return nil, fmt.Errorf("error parsing update role response: %s", err)
 	}
 	if respObj.RequestFailed() {
 		return nil, fmt.Errorf("error from update IAM role request: [%s] %s", respObj.RequestID, strings.Join(respObj.GetErrors(), ", "))
@@ -354,6 +446,33 @@ func (c *Client) DeleteIamRole(id string) error {
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		delErr := new(AlksError)
+		err = decodeBody(resp, &delErr)
+
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return fmt.Errorf(ParseError, err)
+		}
+
+		if delErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, delErr.Errors)
+			}
+
+			return fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, delErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	del := new(DeleteRoleResponse)
@@ -400,6 +519,33 @@ func (c *Client) GetIamRole(roleName string) (*GetIamRoleResponse, error) {
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 || resp.StatusCode != 404 {
+		getErr := new(AlksError)
+		err = decodeBody(resp, &getErr)
+
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return nil, fmt.Errorf(ParseError, err)
+		}
+
+		if getErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, getErr.Errors)
+			}
+
+			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, getErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	cr := new(GetIamRoleResponse)
@@ -461,6 +607,33 @@ func (c *Client) AddRoleMachineIdentity(roleARN string) (*MachineIdentityRespons
 		return nil, err
 	}
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		addErr := new(AlksError)
+		err = decodeBody(resp, &addErr)
+
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return nil, fmt.Errorf(ParseError, err)
+		}
+
+		if addErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, addErr.Errors)
+			}
+
+			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, addErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
+	}
+
 	cr := new(MachineIdentityResponse)
 	err = decodeBody(resp, &cr)
 
@@ -503,6 +676,33 @@ func (c *Client) DeleteRoleMachineIdentity(roleARN string) (*MachineIdentityResp
 		return nil, err
 	}
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		delErr := new(AlksError)
+		err = decodeBody(resp, &delErr)
+
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return nil, fmt.Errorf(ParseError, err)
+		}
+
+		if delErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, delErr.Errors)
+			}
+
+			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, delErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
+	}
+
 	dr := new(MachineIdentityResponse)
 	err = decodeBody(resp, &dr)
 
@@ -543,6 +743,33 @@ func (c *Client) SearchRoleMachineIdentity(roleARN string) (*MachineIdentityResp
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		searchErr := new(AlksError)
+		err = decodeBody(resp, &searchErr)
+
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return nil, fmt.Errorf(ParseError, err)
+		}
+
+		if searchErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf("[%s] ALKS Error Code: %d Msg: %s\n Contact the ALKS Team for assistance on Slack at #alks-client-support", reqID, resp.StatusCode, searchErr.Errors)
+			}
+
+			return nil, fmt.Errorf("ALKS Error Code: %d Msg: %s\n Contact the ALKS Team for assistance on Slack at #alks-client-support", resp.StatusCode, searchErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	sr := new(MachineIdentityResponse)

--- a/iam_role.go
+++ b/iam_role.go
@@ -521,7 +521,7 @@ func (c *Client) GetIamRole(roleName string) (*GetIamRoleResponse, error) {
 		return nil, err
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 || resp.StatusCode != 404 {
+	if (resp.StatusCode < 200 || resp.StatusCode >= 300) && resp.StatusCode != 404 {
 		getErr := new(AlksError)
 		err = decodeBody(resp, &getErr)
 

--- a/login_role.go
+++ b/login_role.go
@@ -24,6 +24,32 @@ func (c *Client) GetMyLoginRole() (*LoginRoleResponse, error) {
 		return nil, err
 	}
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		loginErr := new(AlksError)
+		err = decodeBody(resp, &loginErr)
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return nil, fmt.Errorf(ParseError, err)
+		}
+
+		if loginErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, loginErr.Errors)
+			}
+
+			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, loginErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
+	}
+
 	lrr := new(LoginRoleResponse)
 	err = decodeBody(resp, &lrr)
 	if err != nil {
@@ -69,6 +95,32 @@ func (c *Client) GetLoginRole() (*LoginRoleResponse, error) {
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		loginErr := new(AlksError)
+		err = decodeBody(resp, &loginErr)
+		if err != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			}
+
+			return nil, fmt.Errorf(ParseError, err)
+		}
+
+		if loginErr.Errors != nil {
+			if reqID := GetRequestID(resp); reqID != "" {
+				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, loginErr.Errors)
+			}
+
+			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, loginErr.Errors)
+		}
+
+		if reqID := GetRequestID(resp); reqID != "" {
+			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		}
+
+		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	lrr := new(LoginRoleResponse)


### PR DESCRIPTION
# Description

This PR adds better error handling to the Go client by checking status codes and erroring out before trying to parse response bodies from ALKS-Core. This prevents unclear error messages from propagating to other clients (such as the Terraform Provider) and helps report what the actual error was (a bad response from ALKS).

Rally # (issue / story / spike) [DE283530](https://rally1.rallydev.com/#/?detail=/defect/650276215275&fdp=true): ALKS GO - guard around error codes from ALKS Core

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

## Steps:
  1. Created local test that uses go client communicate with ALKS. MAde errors occur and made sure error messages were correctly displayed.