### PR TITLE
Alks error

### DIFF
--- a/alks_error.go
+++ b/alks_error.go
@@ -5,8 +5,8 @@ import (
 )
 
 type AlksError struct {
-	StatusCode int      
-	RequestId  string   `json:"requestId"`
+	StatusCode int
+	RequestId  string `json:"requestId"`
 	Err        error
 }
 

--- a/alks_error.go
+++ b/alks_error.go
@@ -1,0 +1,28 @@
+package alks
+
+import (
+	"fmt"
+)
+
+type AlksError struct {
+	StatusCode int      
+	RequestId  string   `json:"requestId"`
+	Err        error
+}
+
+func (r *AlksError) Error() string {
+	return fmt.Sprintf("status %d: requestID %s: err %v", r.StatusCode, r.RequestId, r.Err)
+}
+
+type AlksResponseError struct {
+	StatusMessage string   `json:"statusMessage"`
+	Errors        []string `json:"errors"`
+	RequestId     string   `json:"requestId"`
+}
+
+var ErrorStringFull = "[%s] ALKS Error %d Msg: %s\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
+var ErrorStringNoReqId = "ALKS Error %d Msg: %s\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
+var ErrorStringOnlyCodeAndReqId = "[%s] ALKS Error %d\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
+var ErrorStringOnlyCode = "ALKS Error %d\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
+var ParseErrorReqId = "[%s] Error parsing ALKS Error response: %s"
+var ParseError = "Error parsing ALKS Error response: %s"

--- a/api.go
+++ b/api.go
@@ -190,7 +190,7 @@ func (c *Client) Durations() ([]int, error) {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		durationErr := new(AlksError)
+		durationErr := new(AlksResponseError)
 		err = decodeBody(resp, &durationErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {

--- a/iam_ltk.go
+++ b/iam_ltk.go
@@ -90,7 +90,7 @@ func (c *Client) GetLongTermKeys() (*GetLongTermKeysResponse, error) {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		keyErr := new(AlksError)
+		keyErr := new(AlksResponseError)
 		err = decodeBody(resp, &keyErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
@@ -167,7 +167,7 @@ func (c *Client) GetLongTermKey(iamUsername string) (*GetLongTermKeyResponse, er
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		keyErr := new(AlksError)
+		keyErr := new(AlksResponseError)
 		err = decodeBody(resp, &keyErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
@@ -235,7 +235,7 @@ func (c *Client) CreateLongTermKey(iamUsername string) (*CreateLongTermKeyRespon
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		keyErr := new(AlksError)
+		keyErr := new(AlksResponseError)
 		err = decodeBody(resp, &keyErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
@@ -305,7 +305,7 @@ func (c *Client) DeleteLongTermKey(iamUsername string) (*DeleteLongTermKeyRespon
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		keyErr := new(AlksError)
+		keyErr := new(AlksResponseError)
 		err = decodeBody(resp, &keyErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {

--- a/iam_role.go
+++ b/iam_role.go
@@ -177,7 +177,7 @@ func NewIamRoleRequest(options *CreateIamRoleOptions) (*IamRoleRequest, error) {
 
 // CreateIamRole will create a new IAM role in AWS. If no error is returned
 // then you will receive a IamRoleResponse object representing the new role.
-func (c *Client) CreateIamRole(options *CreateIamRoleOptions) (*IamRoleResponse, error) {
+func (c *Client) CreateIamRole(options *CreateIamRoleOptions) (*IamRoleResponse, *AlksError) {
 	request, err := NewIamRoleRequest(options)
 
 	if err != nil {
@@ -266,7 +266,7 @@ func (c *Client) CreateIamRole(options *CreateIamRoleOptions) (*IamRoleResponse,
 
 // CreateIamTrustRole will create a new IAM trust role on AWS. If no error is returned
 // then you will receive a IamRoleResponse object representing the new role.
-func (c *Client) CreateIamTrustRole(options *CreateIamRoleOptions) (*IamRoleResponse, error) {
+func (c *Client) CreateIamTrustRole(options *CreateIamRoleOptions) (*IamRoleResponse, *AlksError) {
 	request, err := NewIamRoleRequest(options)
 
 	b, err := json.Marshal(struct {
@@ -363,7 +363,7 @@ type UpdateIamRoleResponse struct {
 
 /* UpdateIamRole adds resource tags to an existing IAM role.
  */
-func (c *Client) UpdateIamRole(options *UpdateIamRoleRequest) (*UpdateIamRoleResponse, error) {
+func (c *Client) UpdateIamRole(options *UpdateIamRoleRequest) (*UpdateIamRoleResponse, *AlksError) {
 	if err := options.updateIamRoleValidate(); err != nil {
 		return nil, &AlksError{
 			Err: err,
@@ -452,7 +452,7 @@ func (req *UpdateIamRoleRequest) updateIamRoleValidate() error {
 
 // DeleteIamRole will delete an existing IAM role from AWS. If no error is returned
 // then the deletion was successful.
-func (c *Client) DeleteIamRole(id string) error {
+func (c *Client) DeleteIamRole(id string) *AlksError {
 	log.Printf("[INFO] Deleting IAM role: %s", id)
 
 	rmRole := DeleteRoleRequest{id}
@@ -538,7 +538,7 @@ func (c *Client) DeleteIamRole(id string) error {
 // If no error is returned then you will received a IamRoleResponse object
 // representing the existing role. If the role does not exist the IamRoleResponse
 // object will also be nil.
-func (c *Client) GetIamRole(roleName string) (*GetIamRoleResponse, error) {
+func (c *Client) GetIamRole(roleName string) (*GetIamRoleResponse, *AlksError) {
 	log.Printf("[INFO] Getting IAM role: %s", roleName)
 	getRole := GetRoleRequest{roleName}
 
@@ -633,7 +633,7 @@ func (c *Client) GetIamRole(roleName string) (*GetIamRoleResponse, error) {
 
 // AddRoleMachineIdentity enable machine identity for a IamRole.
 // If no error is returned then you will receieve the arn for the machine identity that was created.
-func (c *Client) AddRoleMachineIdentity(roleARN string) (*MachineIdentityResponse, error) {
+func (c *Client) AddRoleMachineIdentity(roleARN string) (*MachineIdentityResponse, *AlksError) {
 	log.Printf("[INFO] Adding role machine identity: %s", roleARN)
 	addMI := AddRoleMachineIdentityRequest{roleARN}
 
@@ -714,7 +714,7 @@ func (c *Client) AddRoleMachineIdentity(roleARN string) (*MachineIdentityRespons
 
 // DeleteRoleMachineIdentity disable machine identity for a IamRole.
 // If no error is returned then you will receieve the arn for the machine identity that was deleted.
-func (c *Client) DeleteRoleMachineIdentity(roleARN string) (*MachineIdentityResponse, error) {
+func (c *Client) DeleteRoleMachineIdentity(roleARN string) (*MachineIdentityResponse, *AlksError) {
 	log.Printf("[INFO] Deleting role machine identity: %s", roleARN)
 	deleteMI := DeleteRoleMachineIdentityRequest{roleARN}
 
@@ -795,7 +795,7 @@ func (c *Client) DeleteRoleMachineIdentity(roleARN string) (*MachineIdentityResp
 
 // SearchRoleMachineIdentity searches for a machine identity for a given roleARN
 // If no error is returned then you will receive the arn of the machine identity for the given roleARN
-func (c *Client) SearchRoleMachineIdentity(roleARN string) (*MachineIdentityResponse, error) {
+func (c *Client) SearchRoleMachineIdentity(roleARN string) (*MachineIdentityResponse, *AlksError) {
 	log.Printf("[INFO] Searching role machine identity: %s", roleARN)
 	searchMI := SearchRoleMachineIdentityRequest{roleARN}
 

--- a/iam_role.go
+++ b/iam_role.go
@@ -182,7 +182,9 @@ func (c *Client) CreateIamRole(options *CreateIamRoleOptions) (*IamRoleResponse,
 
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
@@ -195,21 +197,27 @@ func (c *Client) CreateIamRole(options *CreateIamRoleOptions) (*IamRoleResponse,
 
 	if err != nil {
 		return nil, &AlksError{
-			Err: fmt.Errorf("Error encoding IAM create role JSON: %s", err),
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error encoding IAM create role JSON: %s", err),
 		}
 	}
 
 	req, err := c.NewRequest(b, "POST", "/createRole/")
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
@@ -276,21 +284,27 @@ func (c *Client) CreateIamTrustRole(options *CreateIamRoleOptions) (*IamRoleResp
 
 	if err != nil {
 		return nil, &AlksError{
-			Err: fmt.Errorf("Error encoding IAM create trust role JSON: %s", err),
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error encoding IAM create trust role JSON: %s", err),
 		}
 	}
 
 	req, err := c.NewRequest(b, "POST", "/createNonServiceRole/")
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
@@ -377,19 +391,25 @@ func (c *Client) UpdateIamRole(options *UpdateIamRoleRequest) (*UpdateIamRoleRes
 	}{*options, c.AccountDetails})
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 	req, err := c.NewRequest(b, "PATCH", "/role/")
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
@@ -464,21 +484,27 @@ func (c *Client) DeleteIamRole(id string) *AlksError {
 
 	if err != nil {
 		return &AlksError{
-			Err: fmt.Errorf("Error encoding IAM delete role JSON: %s", err),
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error encoding IAM delete role JSON: %s", err),
 		}
 	}
 
 	req, err := c.NewRequest(b, "POST", "/deleteRole/")
 	if err != nil {
 		return &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
@@ -549,21 +575,27 @@ func (c *Client) GetIamRole(roleName string) (*GetIamRoleResponse, *AlksError) {
 
 	if err != nil {
 		return nil, &AlksError{
-			Err: fmt.Errorf("Error encoding IAM get role JSON: %s", err),
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error encoding IAM get role JSON: %s", err),
 		}
 	}
 
 	req, err := c.NewRequest(b, "POST", "/getAccountRole/")
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
@@ -643,21 +675,27 @@ func (c *Client) AddRoleMachineIdentity(roleARN string) (*MachineIdentityRespons
 
 	if err != nil {
 		return nil, &AlksError{
-			Err: fmt.Errorf("Error encoding add role machine identity JSON: %s", err),
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error encoding add role machine identity JSON: %s", err),
 		}
 	}
 
 	req, err := c.NewRequest(b, "POST", "/roleMachineIdentity/")
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
@@ -724,21 +762,27 @@ func (c *Client) DeleteRoleMachineIdentity(roleARN string) (*MachineIdentityResp
 
 	if err != nil {
 		return nil, &AlksError{
-			Err: fmt.Errorf("Error encoding delete role machine identity JSON: %s", err),
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error encoding delete role machine identity JSON: %s", err),
 		}
 	}
 
 	req, err := c.NewRequest(b, "DELETE", "/roleMachineIdentity/")
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
@@ -805,21 +849,27 @@ func (c *Client) SearchRoleMachineIdentity(roleARN string) (*MachineIdentityResp
 
 	if err != nil {
 		return nil, &AlksError{
-			Err: fmt.Errorf("Error decoding search role machine identity JSON: %s", err),
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error decoding search role machine identity JSON: %s", err),
 		}
 	}
 
 	req, err := c.NewRequest(b, "POST", "/roleMachineIdentity/search/")
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, &AlksError{
-			Err: err,
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
 		}
 	}
 

--- a/iam_role.go
+++ b/iam_role.go
@@ -13,20 +13,6 @@ type Tag struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
-
-type AlksError struct {
-	StatusMessage string   `json:"statusMessage"`
-	Errors        []string `json:"errors"`
-	RequestId     string   `json:"requestId"`
-}
-
-var ErrorStringFull = "[%s] ALKS Error %d Msg: %s\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
-var ErrorStringNoReqId = "ALKS Error %d Msg: %s\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
-var ErrorStringOnlyCodeAndReqId = "[%s] ALKS Error %d\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
-var ErrorStringOnlyCode = "ALKS Error %d\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
-var ParseErrorReqId = "[%s] Error parsing ALKS Error response: %s"
-var ParseError = "Error parsing ALKS Error response: %s"
-
 type CreateIamRoleOptions struct {
 	RoleName                    *string
 	RoleType                    *string
@@ -195,7 +181,9 @@ func (c *Client) CreateIamRole(options *CreateIamRoleOptions) (*IamRoleResponse,
 	request, err := NewIamRoleRequest(options)
 
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 
 	log.Printf("[INFO] Creating IAM role: %s", request.RoleName)
@@ -206,57 +194,71 @@ func (c *Client) CreateIamRole(options *CreateIamRoleOptions) (*IamRoleResponse,
 	}{*request, c.AccountDetails})
 
 	if err != nil {
-		return nil, fmt.Errorf("Error encoding IAM create role JSON: %s", err)
+		return nil, &AlksError{
+			Err: fmt.Errorf("Error encoding IAM create role JSON: %s", err),
+		}
 	}
 
 	req, err := c.NewRequest(b, "POST", "/createRole/")
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
+
+	reqID := GetRequestID(resp)
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		createErr := new(AlksError)
-		err = decodeBody(resp, &createErr)
+		alksResponseErr := new(AlksResponseError)
+		err = decodeBody(resp, &alksResponseErr)
+
 		if err != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ParseErrorReqId, reqID, err),
 			}
-
-			return nil, fmt.Errorf(ParseError, err)
 		}
 
-		if createErr.Errors != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, createErr.Errors)
+		if alksResponseErr.Errors != nil {
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, strings.Join(alksResponseErr.Errors, ", ")),
 			}
-
-			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, createErr.Errors)
 		}
 
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode),
 		}
-
-		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	cr := new(IamRoleResponse)
 	err = decodeBody(resp, &cr)
 
 	if err != nil {
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf("Error parsing CreateRole response: [%s] %s", reqID, err)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error parsing CreateRole response: [%s] %s", reqID, err),
 		}
-
-		return nil, fmt.Errorf("Error parsing CreateRole response: %s", err)
 	}
 
 	if cr.RequestFailed() {
-		return nil, fmt.Errorf("Error creating role: [%s] %s", cr.BaseResponse.RequestID, strings.Join(cr.GetErrors(), ", "))
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error creating role: [%s] %s", cr.BaseResponse.RequestID, strings.Join(cr.GetErrors(), ", ")),
+		}
 	}
 
 	return cr, nil
@@ -273,59 +275,71 @@ func (c *Client) CreateIamTrustRole(options *CreateIamRoleOptions) (*IamRoleResp
 	}{*request, c.AccountDetails})
 
 	if err != nil {
-		return nil, fmt.Errorf("Error encoding IAM create trust role JSON: %s", err)
+		return nil, &AlksError{
+			Err: fmt.Errorf("Error encoding IAM create trust role JSON: %s", err),
+		}
 	}
 
 	req, err := c.NewRequest(b, "POST", "/createNonServiceRole/")
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 
+	reqID := GetRequestID(resp)
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		trustErr := new(AlksError)
+		trustErr := new(AlksResponseError)
 		err = decodeBody(resp, &trustErr)
 
 		if err != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ParseErrorReqId, reqID, err),
 			}
-
-			return nil, fmt.Errorf(ParseError, err)
 		}
 
 		if trustErr.Errors != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, trustErr.Errors)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, strings.Join(trustErr.Errors, ", ")),
 			}
-
-			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, trustErr.Errors)
 		}
 
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode),
 		}
-
-		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	cr := new(IamRoleResponse)
 	err = decodeBody(resp, &cr)
 
 	if err != nil {
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf("Error parsing CreateTrustRole response: [%s] %s", reqID, err)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error parsing CreateTrustRole response: [%s] %s", reqID, err),
 		}
-
-		return nil, fmt.Errorf("Error parsing CreateTrustRole response: %s", err)
 	}
 
 	if cr.RequestFailed() {
-		return nil, fmt.Errorf("Error creating trust role: [%s] %s", cr.BaseResponse.RequestID, strings.Join(cr.GetErrors(), ", "))
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error creating trust role: [%s] %s", cr.BaseResponse.RequestID, strings.Join(cr.GetErrors(), ", ")),
+		}
 	}
 
 	return cr, nil
@@ -351,7 +365,9 @@ type UpdateIamRoleResponse struct {
  */
 func (c *Client) UpdateIamRole(options *UpdateIamRoleRequest) (*UpdateIamRoleResponse, error) {
 	if err := options.updateIamRoleValidate(); err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 	log.Printf("[INFO] update IAM role %s with Tags: %v", *options.RoleName, *options.Tags)
 
@@ -360,55 +376,67 @@ func (c *Client) UpdateIamRole(options *UpdateIamRoleRequest) (*UpdateIamRoleRes
 		AccountDetails
 	}{*options, c.AccountDetails})
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 	req, err := c.NewRequest(b, "PATCH", "/role/")
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 
+	reqID := GetRequestID(resp)
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		updateErr := new(AlksError)
+		updateErr := new(AlksResponseError)
 		err = decodeBody(resp, &updateErr)
 
 		if err != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ParseErrorReqId, reqID, err),
 			}
-
-			return nil, fmt.Errorf(ParseError, err)
 		}
 
 		if updateErr.Errors != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, updateErr.Errors)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, strings.Join(updateErr.Errors, ", ")),
 			}
-
-			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, updateErr.Errors)
 		}
 
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode),
 		}
-
-		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	respObj := &UpdateIamRoleResponse{}
 	if err = decodeBody(resp, respObj); err != nil {
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf("error parsing update role response: [%s] %s", reqID, err)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error parsing updateRole response: [%s] %s", reqID, err),
 		}
-		return nil, fmt.Errorf("error parsing update role response: %s", err)
 	}
 	if respObj.RequestFailed() {
-		return nil, fmt.Errorf("error from update IAM role request: [%s] %s", respObj.RequestID, strings.Join(respObj.GetErrors(), ", "))
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error from update IAM role request: [%s] %s", respObj.RequestID, strings.Join(respObj.GetErrors(), ", ")),
+		}
 	}
-
 	return respObj, nil
 }
 
@@ -435,60 +463,72 @@ func (c *Client) DeleteIamRole(id string) error {
 	}{rmRole, c.AccountDetails})
 
 	if err != nil {
-		return fmt.Errorf("Error encoding IAM delete role JSON: %s", err)
+		return &AlksError{
+			Err: fmt.Errorf("Error encoding IAM delete role JSON: %s", err),
+		}
 	}
 
 	req, err := c.NewRequest(b, "POST", "/deleteRole/")
 	if err != nil {
-		return err
+		return &AlksError{
+			Err: err,
+		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return err
+		return &AlksError{
+			Err: err,
+		}
 	}
 
+	reqID := GetRequestID(resp)
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		delErr := new(AlksError)
+		delErr := new(AlksResponseError)
 		err = decodeBody(resp, &delErr)
 
 		if err != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return fmt.Errorf(ParseErrorReqId, reqID, err)
+			return &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ParseErrorReqId, reqID, err),
 			}
-
-			return fmt.Errorf(ParseError, err)
 		}
 
 		if delErr.Errors != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, delErr.Errors)
+			return &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, strings.Join(delErr.Errors, ", ")),
 			}
-
-			return fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, delErr.Errors)
 		}
 
-		if reqID := GetRequestID(resp); reqID != "" {
-			return fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		return &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode),
 		}
-
-		return fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	del := new(DeleteRoleResponse)
 	err = decodeBody(resp, &del)
 
 	if err != nil {
-		if reqID := GetRequestID(resp); reqID != "" {
-			return fmt.Errorf("Error parsing DeleteRole response: [%s] %s", reqID, err)
+		return &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error parsing deleteRole response: [%s] %s", reqID, err),
 		}
-
-		return fmt.Errorf("Error parsing DeleteRole response: %s", err)
 	}
 
 	// TODO you get an error if you delete an already deleted role, need to revist for checking fail/success
 	if del.RequestFailed() {
-		return fmt.Errorf("Error deleting role: [%s] %s", del.BaseResponse.RequestID, strings.Join(del.GetErrors(), ", "))
+		return &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error deleting role: [%s] %s", del.BaseResponse.RequestID, strings.Join(del.GetErrors(), ", ")),
+		}
 	}
 
 	return nil
@@ -508,62 +548,71 @@ func (c *Client) GetIamRole(roleName string) (*GetIamRoleResponse, error) {
 	}{getRole, c.AccountDetails})
 
 	if err != nil {
-		return nil, fmt.Errorf("Error encoding IAM create role JSON: %s", err)
+		return nil, &AlksError{
+			Err: fmt.Errorf("Error encoding IAM get role JSON: %s", err),
+		}
 	}
 
 	req, err := c.NewRequest(b, "POST", "/getAccountRole/")
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 
-	if (resp.StatusCode < 200 || resp.StatusCode >= 300) && resp.StatusCode != 404 {
-		getErr := new(AlksError)
+	reqID := GetRequestID(resp)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		getErr := new(AlksResponseError)
 		err = decodeBody(resp, &getErr)
 
 		if err != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ParseErrorReqId, reqID, err),
 			}
-
-			return nil, fmt.Errorf(ParseError, err)
 		}
 
 		if getErr.Errors != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, getErr.Errors)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, strings.Join(getErr.Errors, ", ")),
 			}
-
-			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, getErr.Errors)
 		}
 
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode),
 		}
-
-		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	cr := new(GetIamRoleResponse)
 	err = decodeBody(resp, &cr)
 
 	if err != nil {
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf("Error parsing GetRole response: [%s] %s", reqID, err)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error parsing getRole response: [%s] %s", reqID, err),
 		}
-
-		return nil, fmt.Errorf("Error parsing GetRole response: %s", err)
 	}
 
 	if cr.RequestFailed() {
-		if resp.StatusCode == 404 {
-			return cr, fmt.Errorf("Error getting role: [%s] %s", cr.BaseResponse.RequestID, strings.Join(cr.GetErrors(), ", "))
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error getting role: [%s] %s", cr.BaseResponse.RequestID, strings.Join(cr.GetErrors(), ", ")),
 		}
-		return nil, fmt.Errorf("Error getting role: [%s] %s", cr.BaseResponse.RequestID, strings.Join(cr.GetErrors(), ", "))
 	}
 
 	// This is here because ALKS returns a string representation of a Java array
@@ -593,59 +642,71 @@ func (c *Client) AddRoleMachineIdentity(roleARN string) (*MachineIdentityRespons
 	}{addMI})
 
 	if err != nil {
-		return nil, fmt.Errorf("Error encoding add role machine identity JSON: %s", err)
+		return nil, &AlksError{
+			Err: fmt.Errorf("Error encoding add role machine identity JSON: %s", err),
+		}
 	}
 
 	req, err := c.NewRequest(b, "POST", "/roleMachineIdentity/")
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 
+	reqID := GetRequestID(resp)
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		addErr := new(AlksError)
+		addErr := new(AlksResponseError)
 		err = decodeBody(resp, &addErr)
 
 		if err != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ParseErrorReqId, reqID, err),
 			}
-
-			return nil, fmt.Errorf(ParseError, err)
 		}
 
 		if addErr.Errors != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, addErr.Errors)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, strings.Join(addErr.Errors, ", ")),
 			}
-
-			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, addErr.Errors)
 		}
 
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode),
 		}
-
-		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	cr := new(MachineIdentityResponse)
 	err = decodeBody(resp, &cr)
 
 	if err != nil {
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf("Error parsing MachineIdentitiyResponse: [%s] %s", reqID, err)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error parsing MachineIdentitiyResponse response: [%s] %s", reqID, err),
 		}
-
-		return nil, fmt.Errorf("Error parsing MachineIdentityResponse: %s", err)
 	}
 
 	if cr.RequestFailed() {
-		return nil, fmt.Errorf("Error creating machine identity: [%s] %s", cr.BaseResponse.RequestID, strings.Join(cr.GetErrors(), ", "))
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error creating machine identity: [%s] %s", cr.BaseResponse.RequestID, strings.Join(cr.GetErrors(), ", ")),
+		}
 	}
 
 	return cr, nil
@@ -662,59 +723,71 @@ func (c *Client) DeleteRoleMachineIdentity(roleARN string) (*MachineIdentityResp
 	}{deleteMI})
 
 	if err != nil {
-		return nil, fmt.Errorf("Error encoding delete role machine identity JSON: %s", err)
+		return nil, &AlksError{
+			Err: fmt.Errorf("Error encoding delete role machine identity JSON: %s", err),
+		}
 	}
 
 	req, err := c.NewRequest(b, "DELETE", "/roleMachineIdentity/")
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 
+	reqID := GetRequestID(resp)
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		delErr := new(AlksError)
+		delErr := new(AlksResponseError)
 		err = decodeBody(resp, &delErr)
 
 		if err != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ParseErrorReqId, reqID, err),
 			}
-
-			return nil, fmt.Errorf(ParseError, err)
 		}
 
 		if delErr.Errors != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, delErr.Errors)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, strings.Join(delErr.Errors, ", ")),
 			}
-
-			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, delErr.Errors)
 		}
 
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode),
 		}
-
-		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	dr := new(MachineIdentityResponse)
 	err = decodeBody(resp, &dr)
 
 	if err != nil {
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf("Error parsing MachineIdentityResponse: [%s] %s", reqID, err)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error parsing machineIdentity response: [%s] %s", reqID, err),
 		}
-
-		return nil, fmt.Errorf("Error parsing MachineIdenttiyResponse: %s", err)
 	}
 
 	if dr.RequestFailed() {
-		return nil, fmt.Errorf("Error deleting machine identity: [%s] %s", dr.BaseResponse.RequestID, strings.Join(dr.GetErrors(), ", "))
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error deleting machine identity: [%s] %s", dr.BaseResponse.RequestID, strings.Join(dr.GetErrors(), ", ")),
+		}
 	}
 
 	return dr, nil
@@ -731,59 +804,71 @@ func (c *Client) SearchRoleMachineIdentity(roleARN string) (*MachineIdentityResp
 	}{searchMI})
 
 	if err != nil {
-		return nil, fmt.Errorf("Error decoding search role machine identity JSON: %s", err)
+		return nil, &AlksError{
+			Err: fmt.Errorf("Error decoding search role machine identity JSON: %s", err),
+		}
 	}
 
 	req, err := c.NewRequest(b, "POST", "/roleMachineIdentity/search/")
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			Err: err,
+		}
 	}
 
+	reqID := GetRequestID(resp)
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		searchErr := new(AlksError)
+		searchErr := new(AlksResponseError)
 		err = decodeBody(resp, &searchErr)
 
 		if err != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ParseErrorReqId, reqID, err),
 			}
-
-			return nil, fmt.Errorf(ParseError, err)
 		}
 
 		if searchErr.Errors != nil {
-			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf("[%s] ALKS Error Code: %d Msg: %s\n Contact the ALKS Team for assistance on Slack at #alks-client-support", reqID, resp.StatusCode, searchErr.Errors)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, strings.Join(searchErr.Errors, ", ")),
 			}
-
-			return nil, fmt.Errorf("ALKS Error Code: %d Msg: %s\n Contact the ALKS Team for assistance on Slack at #alks-client-support", resp.StatusCode, searchErr.Errors)
 		}
 
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode),
 		}
-
-		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
 	}
 
 	sr := new(MachineIdentityResponse)
 	err = decodeBody(resp, &sr)
 
 	if err != nil {
-		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf("Error parsing MachineIdentityResponse: [%s] %s", reqID, err)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error parsing MachineIdentity response: [%s] %s", reqID, err),
 		}
-
-		return nil, fmt.Errorf("Error parsing MachineIdentityResponse: %s", err)
 	}
 
 	if sr.RequestFailed() {
-		return nil, fmt.Errorf("Error searching machine identity [%s] %s", sr.BaseResponse.RequestID, strings.Join(sr.GetErrors(), ", "))
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  reqID,
+			Err:        fmt.Errorf("Error searching machine identity [%s] %s", sr.BaseResponse.RequestID, strings.Join(sr.GetErrors(), ", ")),
+		}
 	}
 
 	return sr, nil

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -253,8 +253,9 @@ func (s *S) Test_GetIamRoleMissing(c *C) {
 
 	_ = testServer.WaitRequest()
 
-	c.Assert(resp, NotNil)
-	c.Assert(err, IsNil)
+	c.Assert(resp, IsNil)
+	c.Assert(err, NotNil)
+	c.Assert(err.StatusCode, Equals, 404)
 }
 
 func (s *S) Test_GetIamRoleInternalError(c *C) {
@@ -266,6 +267,7 @@ func (s *S) Test_GetIamRoleInternalError(c *C) {
 
 	c.Assert(resp, IsNil)
 	c.Assert(err, NotNil)
+	c.Assert(err.StatusCode, Equals, 500)
 }
 
 func (s *S) Test_UpdateIamRole(c *C) {

--- a/is_iam_enabled.go
+++ b/is_iam_enabled.go
@@ -51,7 +51,7 @@ func (c *Client) IsIamEnabled(roleArn string) (*IsIamEnabledResponse, error) {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		iamErr := new(AlksError)
+		iamErr := new(AlksResponseError)
 		err = decodeBody(resp, &iamErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {

--- a/login_role.go
+++ b/login_role.go
@@ -25,7 +25,7 @@ func (c *Client) GetMyLoginRole() (*LoginRoleResponse, error) {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		loginErr := new(AlksError)
+		loginErr := new(AlksResponseError)
 		err = decodeBody(resp, &loginErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
@@ -98,7 +98,7 @@ func (c *Client) GetLoginRole() (*LoginRoleResponse, error) {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		loginErr := new(AlksError)
+		loginErr := new(AlksResponseError)
 		err = decodeBody(resp, &loginErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {


### PR DESCRIPTION
# Description

AlksError refactored to include status code.  Errors now return the AlksError struct rather then a simple error string

Rally # [DE286403](https://rally1.rallydev.com/#/?detail=/defect/659072671783&fdp=true): ALKS Go - Refactor to use new AlksError

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

## Steps:
  1. unit tests
  2. manual local tests

# Checklist / To Do:

- [ ] Merge to master
