### PR TITLE
refactor to use ALKSError throughout client

### DIFF
--- a/api.go
+++ b/api.go
@@ -212,7 +212,7 @@ func (c *Client) Durations() ([]int, error) {
 			if reqID := GetRequestID(resp); reqID != "" {
 				return nil, &AlksError{
 					StatusCode: resp.StatusCode,
-					RequestId:  "",
+					RequestId:  reqID,
 					Err:        fmt.Errorf(ParseErrorReqId, reqID, err),
 				}
 			}

--- a/api.go
+++ b/api.go
@@ -198,7 +198,11 @@ func (c *Client) Durations() ([]int, error) {
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  "",
+			Err:        err,
+		}
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -256,7 +260,7 @@ func (c *Client) Durations() ([]int, error) {
 	if err != nil {
 		if reqID := GetRequestID(resp); reqID != "" {
 			return nil, &AlksError{
-				StatusCode: 0,
+				StatusCode: resp.StatusCode,
 				RequestId:  reqID,
 				Err:        fmt.Errorf("Error parsing LoginRole response: [%s] %s", reqID, err),
 			}
@@ -264,7 +268,7 @@ func (c *Client) Durations() ([]int, error) {
 		}
 
 		return nil, &AlksError{
-			StatusCode: 0,
+			StatusCode: resp.StatusCode,
 			RequestId:  "",
 			Err:        fmt.Errorf("Error parsing LoginRole response: %s", err),
 		}
@@ -272,7 +276,7 @@ func (c *Client) Durations() ([]int, error) {
 
 	if lrr.RequestFailed() {
 		return nil, &AlksError{
-			StatusCode: 0,
+			StatusCode: resp.StatusCode,
 			RequestId:  lrr.BaseResponse.RequestID,
 			Err:        fmt.Errorf("Error fetching role information: [%s] %s", lrr.BaseResponse.RequestID, strings.Join(lrr.GetErrors(), ", ")),
 		}

--- a/is_iam_enabled.go
+++ b/is_iam_enabled.go
@@ -57,7 +57,7 @@ func (c *Client) IsIamEnabled(roleArn string) (*IsIamEnabledResponse, error) {
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, &AlksError{
-			StatusCode: 0,
+			StatusCode: resp.StatusCode,
 			RequestId:  "",
 			Err:        err,
 		}
@@ -120,21 +120,21 @@ func (c *Client) IsIamEnabled(roleArn string) (*IsIamEnabledResponse, error) {
 	if err != nil {
 		if reqID := GetRequestID(resp); reqID != "" {
 			return nil, &AlksError{
-				StatusCode: 0,
+				StatusCode: resp.StatusCode,
 				RequestId:  reqID,
 				Err:        fmt.Errorf("error parsing isIamEnabled response: [%s] %s", reqID, err),
 			}
 		}
 
 		return nil, &AlksError{
-			StatusCode: 0,
+			StatusCode: resp.StatusCode,
 			RequestId:  "",
 			Err:        fmt.Errorf("error parsing isIamEnabled response: %s", err),
 		}
 	}
 	if validate.RequestFailed() {
 		return nil, &AlksError{
-			StatusCode: 0,
+			StatusCode: resp.StatusCode,
 			RequestId:  validate.BaseResponse.RequestID,
 			Err:        fmt.Errorf("error validating if IAM enabled: [%s] %s", validate.BaseResponse.RequestID, strings.Join(validate.GetErrors(), ", ")),
 		}

--- a/is_iam_enabled.go
+++ b/is_iam_enabled.go
@@ -37,17 +37,31 @@ func (c *Client) IsIamEnabled(roleArn string) (*IsIamEnabledResponse, error) {
 	body, err := json.Marshal(iam)
 
 	if err != nil {
-		return nil, fmt.Errorf("error encoding IAM create role JSON: %s", err)
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("error encoding IAM create role JSON: %s", err),
+		}
+
 	}
 
 	req, err := c.NewRequest(body, "POST", "/isIamEnabled")
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
+		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
+		}
+
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -55,25 +69,49 @@ func (c *Client) IsIamEnabled(roleArn string) (*IsIamEnabledResponse, error) {
 		err = decodeBody(resp, &iamErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+				return nil, &AlksError{
+					StatusCode: resp.StatusCode,
+					RequestId:  reqID,
+					Err:        fmt.Errorf(ParseErrorReqId, reqID, err),
+				}
 			}
 
-			return nil, fmt.Errorf(ParseError, err)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  "",
+				Err:        fmt.Errorf(ParseError, err),
+			}
 		}
 
 		if iamErr.Errors != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, iamErr.Errors)
+				return nil, &AlksError{
+					StatusCode: resp.StatusCode,
+					RequestId:  reqID,
+					Err:        fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, iamErr.Errors),
+				}
 			}
 
-			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, iamErr.Errors)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  "",
+				Err:        fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, iamErr.Errors),
+			}
 		}
 
 		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode),
+			}
 		}
 
-		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  "",
+			Err:        fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode),
+		}
 	}
 
 	validate := new(IsIamEnabledResponse)
@@ -81,13 +119,25 @@ func (c *Client) IsIamEnabled(roleArn string) (*IsIamEnabledResponse, error) {
 
 	if err != nil {
 		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf("error parsing isIamEnabled response: [%s] %s", reqID, err)
+			return nil, &AlksError{
+				StatusCode: 0,
+				RequestId:  reqID,
+				Err:        fmt.Errorf("error parsing isIamEnabled response: [%s] %s", reqID, err),
+			}
 		}
 
-		return nil, fmt.Errorf("error parsing isIamEnabled response: %s", err)
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("error parsing isIamEnabled response: %s", err),
+		}
 	}
 	if validate.RequestFailed() {
-		return nil, fmt.Errorf("error validating if IAM enabled: [%s] %s", validate.BaseResponse.RequestID, strings.Join(validate.GetErrors(), ", "))
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  validate.BaseResponse.RequestID,
+			Err:        fmt.Errorf("error validating if IAM enabled: [%s] %s", validate.BaseResponse.RequestID, strings.Join(validate.GetErrors(), ", ")),
+		}
 	}
 
 	return validate, nil

--- a/login_role.go
+++ b/login_role.go
@@ -11,17 +11,29 @@ func (c *Client) GetMyLoginRole() (*LoginRoleResponse, error) {
 	log.Printf("[INFO] Requesting Login Role information from ALKS")
 
 	if !c.IsUsingSTSCredentials() {
-		return nil, fmt.Errorf("GetMyLoginRole only supports clients using STS credentials, try using GetLoginRole instead")
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("GetMyLoginRole only supports clients using STS credentials, try using GetLoginRole instead"),
+		}
 	}
 
 	req, err := c.NewRequest(nil, "GET", "/loginRoles/id/me")
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
+		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
+		}
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -29,39 +41,75 @@ func (c *Client) GetMyLoginRole() (*LoginRoleResponse, error) {
 		err = decodeBody(resp, &loginErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+				return nil, &AlksError{
+					StatusCode: resp.StatusCode,
+					RequestId:  reqID,
+					Err:        fmt.Errorf(ParseErrorReqId, reqID, err),
+				}
 			}
 
-			return nil, fmt.Errorf(ParseError, err)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  "",
+				Err:        fmt.Errorf(ParseError, err),
+			}
 		}
 
 		if loginErr.Errors != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, loginErr.Errors)
+				return nil, &AlksError{
+					StatusCode: resp.StatusCode,
+					RequestId:  reqID,
+					Err:        fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, loginErr.Errors),
+				}
 			}
 
-			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, loginErr.Errors)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  "",
+				Err:        fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, loginErr.Errors),
+			}
 		}
 
 		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode),
+			}
 		}
 
-		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  "",
+			Err:        fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode),
+		}
 	}
 
 	lrr := new(LoginRoleResponse)
 	err = decodeBody(resp, &lrr)
 	if err != nil {
 		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf("Error parsing LoginRole response: [%s] %s", reqID, err)
+			return nil, &AlksError{
+				StatusCode: 0,
+				RequestId:  reqID,
+				Err:        fmt.Errorf("Error parsing LoginRole response: [%s] %s", reqID, err),
+			}
 		}
 
-		return nil, fmt.Errorf("Error parsing LoginRole response: %s", err)
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error parsing LoginRole response: %s", err),
+		}
 	}
 
 	if lrr.RequestFailed() {
-		return nil, fmt.Errorf("Error fetching role information: [%s] %s", lrr.BaseResponse.RequestID, strings.Join(lrr.GetErrors(), ", "))
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  lrr.BaseResponse.RequestID,
+			Err:        fmt.Errorf("Error fetching role information: [%s] %s", lrr.BaseResponse.RequestID, strings.Join(lrr.GetErrors(), ", ")),
+		}
 	}
 
 	return lrr, nil
@@ -77,24 +125,40 @@ func (c *Client) GetLoginRole() (*LoginRoleResponse, error) {
 
 	account, err := c.AccountDetails.GetAccountNumber()
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
+		}
 	}
 
 	roleName, err := c.AccountDetails.GetRoleName(false)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
+		}
 	}
 
 	log.Printf("[INFO] Requesting Login Role information for %v/%v from ALKS", account, roleName)
 
 	req, err := c.NewRequest(nil, "GET", fmt.Sprintf("/loginRoles/id/%v/%v", account, roleName))
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
+		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
+		}
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -102,39 +166,75 @@ func (c *Client) GetLoginRole() (*LoginRoleResponse, error) {
 		err = decodeBody(resp, &loginErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ParseErrorReqId, reqID, err)
+				return nil, &AlksError{
+					StatusCode: resp.StatusCode,
+					RequestId:  reqID,
+					Err:        fmt.Errorf(ParseErrorReqId, reqID, err),
+				}
 			}
 
-			return nil, fmt.Errorf(ParseError, err)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  "",
+				Err:        fmt.Errorf(ParseError, err),
+			}
 		}
 
 		if loginErr.Errors != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
-				return nil, fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, loginErr.Errors)
+				return nil, &AlksError{
+					StatusCode: resp.StatusCode,
+					RequestId:  reqID,
+					Err:        fmt.Errorf(ErrorStringFull, reqID, resp.StatusCode, loginErr.Errors),
+				}
 			}
 
-			return nil, fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, loginErr.Errors)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  "",
+				Err:        fmt.Errorf(ErrorStringNoReqId, resp.StatusCode, loginErr.Errors),
+			}
 		}
 
 		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf(ErrorStringOnlyCodeAndReqId, reqID, resp.StatusCode),
+			}
 		}
 
-		return nil, fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  "",
+			Err:        fmt.Errorf(ErrorStringOnlyCode, resp.StatusCode),
+		}
 	}
 
 	lrr := new(LoginRoleResponse)
 	err = decodeBody(resp, &lrr)
 	if err != nil {
 		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf("Error parsing LoginRole response: [%s] %s", reqID, err)
+			return nil, &AlksError{
+				StatusCode: 0,
+				RequestId:  reqID,
+				Err:        fmt.Errorf("Error parsing LoginRole response: [%s] %s", reqID, err),
+			}
 		}
 
-		return nil, fmt.Errorf("Error parsing LoginRole response: %s", err)
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error parsing LoginRole response: %s", err),
+		}
 	}
 
 	if lrr.RequestFailed() {
-		return nil, fmt.Errorf("Error fetching role information: [%s] %s", lrr.BaseResponse.RequestID, strings.Join(lrr.GetErrors(), ", "))
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  lrr.BaseResponse.RequestID,
+			Err:        fmt.Errorf("Error fetching role information: [%s] %s", lrr.BaseResponse.RequestID, strings.Join(lrr.GetErrors(), ", ")),
+		}
 	}
 
 	return lrr, nil

--- a/login_role.go
+++ b/login_role.go
@@ -155,7 +155,7 @@ func (c *Client) GetLoginRole() (*LoginRoleResponse, error) {
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, &AlksError{
-			StatusCode: 0,
+			StatusCode: resp.StatusCode,
 			RequestId:  "",
 			Err:        err,
 		}
@@ -216,14 +216,14 @@ func (c *Client) GetLoginRole() (*LoginRoleResponse, error) {
 	if err != nil {
 		if reqID := GetRequestID(resp); reqID != "" {
 			return nil, &AlksError{
-				StatusCode: 0,
+				StatusCode: resp.StatusCode,
 				RequestId:  reqID,
 				Err:        fmt.Errorf("Error parsing LoginRole response: [%s] %s", reqID, err),
 			}
 		}
 
 		return nil, &AlksError{
-			StatusCode: 0,
+			StatusCode: resp.StatusCode,
 			RequestId:  "",
 			Err:        fmt.Errorf("Error parsing LoginRole response: %s", err),
 		}
@@ -231,7 +231,7 @@ func (c *Client) GetLoginRole() (*LoginRoleResponse, error) {
 
 	if lrr.RequestFailed() {
 		return nil, &AlksError{
-			StatusCode: 0,
+			StatusCode: resp.StatusCode,
 			RequestId:  lrr.BaseResponse.RequestID,
 			Err:        fmt.Errorf("Error fetching role information: [%s] %s", lrr.BaseResponse.RequestID, strings.Join(lrr.GetErrors(), ", ")),
 		}

--- a/session.go
+++ b/session.go
@@ -56,17 +56,29 @@ func (c *Client) GetAccounts() (*AccountsResponse, error) {
 	b, err := json.Marshal(c.Credentials)
 
 	if err != nil {
-		return nil, fmt.Errorf("Error encoding account request JSON: %s", err)
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error encoding account request JSON: %s", err),
+		}
 	}
 
 	req, err := c.NewRequest(b, "POST", "/getAccounts/")
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
+		}
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
+		}
 	}
 
 	_accts := new(AccountsResponseInt)
@@ -74,14 +86,26 @@ func (c *Client) GetAccounts() (*AccountsResponse, error) {
 
 	if err != nil {
 		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf("Error parsing get accounts response: [%s] %s", reqID, err)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf("Error parsing get accounts response: [%s] %s", reqID, err),
+			}
 		}
 
-		return nil, fmt.Errorf("Error parsing get accounts response: %s", err)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error parsing get accounts response: %s", err),
+		}
 	}
 
 	if _accts.RequestFailed() {
-		return nil, fmt.Errorf("Error getting accounts : [%s] %s", _accts.BaseResponse.RequestID, strings.Join(_accts.GetErrors(), ", "))
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  _accts.BaseResponse.RequestID,
+			Err:        fmt.Errorf("Error getting accounts : [%s] %s", _accts.BaseResponse.RequestID, strings.Join(_accts.GetErrors(), ", ")),
+		}
 	}
 
 	accts := new(AccountsResponse)
@@ -102,7 +126,11 @@ func (c *Client) CreateSession(sessionDuration int, useIAM bool) (*SessionRespon
 	var found = false
 	durations, err := c.Durations()
 	if err != nil {
-		return nil, fmt.Errorf("Error fetching allowable durations from ALKS: %s", err)
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error fetching allowable durations from ALKS: %s", err),
+		}
 	}
 
 	for _, v := range durations {
@@ -112,7 +140,11 @@ func (c *Client) CreateSession(sessionDuration int, useIAM bool) (*SessionRespon
 	}
 
 	if !found {
-		return nil, fmt.Errorf("Unsupported session duration")
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("Unsupported session duration"),
+		}
 	}
 
 	session := SessionRequest{sessionDuration}
@@ -123,7 +155,11 @@ func (c *Client) CreateSession(sessionDuration int, useIAM bool) (*SessionRespon
 	}{session, c.AccountDetails})
 
 	if err != nil {
-		return nil, fmt.Errorf("Error encoding session create JSON: %s", err)
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error encoding session create JSON: %s", err),
+		}
 	}
 
 	var endpoint = "/getKeys/"
@@ -132,12 +168,20 @@ func (c *Client) CreateSession(sessionDuration int, useIAM bool) (*SessionRespon
 	}
 	req, err := c.NewRequest(b, "POST", endpoint)
 	if err != nil {
-		return nil, err
+		return nil, &AlksError{
+			StatusCode: 0,
+			RequestId:  "",
+			Err:        err,
+		}
 	}
 
 	resp, httpErr := c.http.Do(req)
 	if httpErr != nil {
-		return nil, err
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  "",
+			Err:        err,
+		}
 	}
 
 	sr := new(SessionResponse)
@@ -145,14 +189,26 @@ func (c *Client) CreateSession(sessionDuration int, useIAM bool) (*SessionRespon
 
 	if err != nil {
 		if reqID := GetRequestID(resp); reqID != "" {
-			return nil, fmt.Errorf("Error parsing session create response: [%s] %s", reqID, err)
+			return nil, &AlksError{
+				StatusCode: resp.StatusCode,
+				RequestId:  reqID,
+				Err:        fmt.Errorf("Error parsing session create response: [%s] %s", reqID, err),
+			}
 		}
 
-		return nil, fmt.Errorf("Error parsing session create response: %s", err)
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  "",
+			Err:        fmt.Errorf("Error parsing session create response: %s", err),
+		}
 	}
 
 	if sr.RequestFailed() {
-		return nil, fmt.Errorf("Error creating session: [%s] %s", sr.BaseResponse.RequestID, strings.Join(sr.GetErrors(), ", "))
+		return nil, &AlksError{
+			StatusCode: resp.StatusCode,
+			RequestId:  sr.BaseResponse.RequestID,
+			Err:        fmt.Errorf("Error creating session: [%s] %s", sr.BaseResponse.RequestID, strings.Join(sr.GetErrors(), ", ")),
+		}
 	}
 
 	sr.Expires = time.Now().Local().Add(time.Hour * time.Duration(sessionDuration))


### PR DESCRIPTION
# Description

This PR refactors the remaining errors in alks-go to use the new AlksError class so that more information can be provided to the TFP when an error occurs talking to ALKS-Core.

Rally # [DE286403](https://rally1.rallydev.com/#/?detail=/defect/659072671783&fdp=true): ALKS Go - Refactor to use new AlksError

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


# How has this been tested?

## Steps:
  1. Unit test
