### PR TITLE
Update role trust policy

### DIFF
--- a/iam_role.go
+++ b/iam_role.go
@@ -376,7 +376,7 @@ type UpdateIamRoleResponse struct {
 	Tags            *[]Tag  `json:"tags"`
 }
 
-// Updates IAM role tags and/or trust policy
+// Updates an IAM role with the given options.
 func (c *Client) UpdateIamRole(options *UpdateIamRoleRequest) (*UpdateIamRoleResponse, *AlksError) {
 	if err := options.updateIamRoleValidate(); err != nil {
 		return nil, &AlksError{

--- a/iam_role.go
+++ b/iam_role.go
@@ -385,11 +385,11 @@ func (c *Client) UpdateIamRole(options *UpdateIamRoleRequest) (*UpdateIamRoleRes
 			Err:        err,
 		}
 	}
-	// accounts for a non empty tag object
+	// considering a non empty tag object
 	if options.Tags != nil {
 		log.Printf("[INFO] update IAM role %s with tags: %v", *options.RoleName, *options.Tags)
 	}
-	// accounts for a non empty TrustPolicy map
+	// considering a non empty TrustPolicy map
 	if options.TrustPolicy != nil {
 		log.Printf("[INFO] update IAM role %s with trust policy: %v", *options.RoleName, *options.TrustPolicy)
 	}
@@ -472,9 +472,6 @@ func (c *Client) UpdateIamRole(options *UpdateIamRoleRequest) (*UpdateIamRoleRes
 func (req *UpdateIamRoleRequest) updateIamRoleValidate() error {
 	if req.RoleName == nil {
 		return fmt.Errorf("roleName option must not be nil")
-	}
-	if req.Tags == nil && req.TrustPolicy == nil {
-		return fmt.Errorf("Either tags or trust policy must not be nil")
 	}
 	return nil
 }

--- a/iam_role.go
+++ b/iam_role.go
@@ -360,8 +360,9 @@ func (c *Client) CreateIamTrustRole(options *CreateIamRoleOptions) (*IamRoleResp
 }
 
 type UpdateIamRoleRequest struct {
-	RoleName *string `json:"roleName"`
-	Tags     *[]Tag  `json:"tags"`
+	RoleName    *string                 `json:"roleName"`
+	Tags        *[]Tag                  `json:"tags"`
+	TrustPolicy *map[string]interface{} `json:"trustPolicy"`
 }
 
 type UpdateIamRoleResponse struct {
@@ -375,8 +376,7 @@ type UpdateIamRoleResponse struct {
 	Tags            *[]Tag  `json:"tags"`
 }
 
-/* UpdateIamRole adds resource tags to an existing IAM role.
- */
+// Updates IAM role tags and/or trust policy
 func (c *Client) UpdateIamRole(options *UpdateIamRoleRequest) (*UpdateIamRoleResponse, *AlksError) {
 	if err := options.updateIamRoleValidate(); err != nil {
 		return nil, &AlksError{
@@ -385,7 +385,14 @@ func (c *Client) UpdateIamRole(options *UpdateIamRoleRequest) (*UpdateIamRoleRes
 			Err:        err,
 		}
 	}
-	log.Printf("[INFO] update IAM role %s with Tags: %v", *options.RoleName, *options.Tags)
+	// accounts for a non empty tag object
+	if options.Tags != nil {
+		log.Printf("[INFO] update IAM role %s with tags: %v", *options.RoleName, *options.Tags)
+	}
+	// accounts for a non empty TrustPolicy map
+	if options.TrustPolicy != nil {
+		log.Printf("[INFO] update IAM role %s with trust policy: %v", *options.RoleName, *options.TrustPolicy)
+	}
 
 	b, err := json.Marshal(struct {
 		UpdateIamRoleRequest
@@ -466,8 +473,8 @@ func (req *UpdateIamRoleRequest) updateIamRoleValidate() error {
 	if req.RoleName == nil {
 		return fmt.Errorf("roleName option must not be nil")
 	}
-	if req.Tags == nil {
-		return fmt.Errorf("tags option must not be nil")
+	if req.Tags == nil && req.TrustPolicy == nil {
+		return fmt.Errorf("Either tags or trust policy must not be nil")
 	}
 	return nil
 }

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -270,7 +270,7 @@ func (s *S) Test_GetIamRoleInternalError(c *C) {
 	c.Assert(err.StatusCode, Equals, 500)
 }
 
-func (s *S) Test_UpdateIamRole(c *C) {
+func (s *S) Test_UpdateIamRoleTags(c *C) {
 	testServer.Response(202, nil, updateRoleResponse)
 
 	roleName := "test-update-role"
@@ -291,7 +291,55 @@ func (s *S) Test_UpdateIamRole(c *C) {
 
 	c.Assert(err, IsNil)
 	c.Assert(resp, NotNil)
-	c.Assert(*resp.RoleName, Equals, "test-update-role")
+	c.Assert(*resp.RoleName, Equals, roleName)
+	c.Assert(*resp.Tags, NotNil)
+}
+
+func (s *S) Test_UpdateIamRoleTrustPolicy(c *C) {
+	testServer.Response(202, nil, updateRoleResponse)
+
+	roleName := "test-update-role"
+	trustPolicy := new(map[string]interface{})
+	json.Unmarshal(
+		[]byte(`{"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Service":"ecs-tasks.amazonaws.com"},"Action":"sts:AssumeRole"}]}`),
+		trustPolicy)
+	req := &UpdateIamRoleRequest{RoleName: &roleName, TrustPolicy: trustPolicy}
+	resp, err := s.client.UpdateIamRole(req)
+
+	_ = testServer.WaitRequest()
+
+	c.Assert(err, IsNil)
+	c.Assert(resp, NotNil)
+	c.Assert(*resp.RoleName, Equals, roleName)
+	c.Assert(*resp.Tags, NotNil)
+}
+
+func (s *S) Test_UpdateIamRoleTagsAndTrustPolicy(c *C) {
+	testServer.Response(202, nil, updateRoleResponse)
+
+	roleName := "test-update-role"
+	tags := []Tag{
+		{
+			Key:   "cai-owner",
+			Value: "123456",
+		},
+		{
+			Key:   "cai-person",
+			Value: "161803",
+		},
+	}
+	trustPolicy := new(map[string]interface{})
+	json.Unmarshal(
+		[]byte(`{"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Service":"ecs-tasks.amazonaws.com"},"Action":"sts:AssumeRole"}]}`),
+		trustPolicy)
+	req := &UpdateIamRoleRequest{RoleName: &roleName, Tags: &tags, TrustPolicy: trustPolicy}
+	resp, err := s.client.UpdateIamRole(req)
+
+	_ = testServer.WaitRequest()
+
+	c.Assert(err, IsNil)
+	c.Assert(resp, NotNil)
+	c.Assert(*resp.RoleName, Equals, roleName)
 	c.Assert(*resp.Tags, NotNil)
 }
 

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -270,10 +270,12 @@ func (s *S) Test_GetIamRoleInternalError(c *C) {
 	c.Assert(err.StatusCode, Equals, 500)
 }
 
+const RoleName = "test-update-role"
+
 func (s *S) Test_UpdateIamRoleTags(c *C) {
 	testServer.Response(202, nil, updateRoleResponse)
 
-	roleName := "test-update-role"
+	roleName := RoleName
 	tags := []Tag{
 		{
 			Key:   "cai-owner",
@@ -298,7 +300,7 @@ func (s *S) Test_UpdateIamRoleTags(c *C) {
 func (s *S) Test_UpdateIamRoleTrustPolicy(c *C) {
 	testServer.Response(202, nil, updateRoleResponse)
 
-	roleName := "test-update-role"
+	roleName := RoleName
 	trustPolicy := new(map[string]interface{})
 	json.Unmarshal(
 		[]byte(`{"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Service":"ecs-tasks.amazonaws.com"},"Action":"sts:AssumeRole"}]}`),
@@ -317,7 +319,7 @@ func (s *S) Test_UpdateIamRoleTrustPolicy(c *C) {
 func (s *S) Test_UpdateIamRoleTagsAndTrustPolicy(c *C) {
 	testServer.Response(202, nil, updateRoleResponse)
 
-	roleName := "test-update-role"
+	roleName := RoleName
 	tags := []Tag{
 		{
 			Key:   "cai-owner",
@@ -341,6 +343,20 @@ func (s *S) Test_UpdateIamRoleTagsAndTrustPolicy(c *C) {
 	c.Assert(resp, NotNil)
 	c.Assert(*resp.RoleName, Equals, roleName)
 	c.Assert(*resp.Tags, NotNil)
+}
+
+func (s *S) Test_UpdateIamRoleNoTagsNoTrustPolicy(c *C) {
+	testServer.Response(200, nil, updateRoleResponse)
+
+	roleName := RoleName
+	req := &UpdateIamRoleRequest{RoleName: &roleName}
+	resp, err := s.client.UpdateIamRole(req)
+
+	_ = testServer.WaitRequest()
+
+	c.Assert(err, IsNil)
+	c.Assert(resp, NotNil)
+	c.Assert(*resp.RoleName, Equals, roleName)
 }
 
 func (s *S) Test_DeleteIamRole(c *C) {


### PR DESCRIPTION
# Description

* Adds Trust policy field to UpdateIamRoleRequest object.
* Removes UpdateRoleRequest validation of object existence.

Rally # [US1120114](https://rally1.rallydev.com/#/?detail=/userstory/707405115875&fdp=true): ALKS GO - Enable in place trust policy editing

The validation changes should probably be discussed. My brain tells me that requiring at least one of either a tags object or trust policy will snowball into validating for at least one of whatever we allow to be updated in the future. I don't think a request should fail if a user calls this function with no target objects to change. 