### PR TITLE
Fix broken dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,5 @@ go 1.16
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.0
-	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6
-	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,13 @@
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 h1:gKdQPVb3yDSbcw4sgNyrt2LP0/4uTdrvTm3e4IcATCE=
 github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6/go.mod h1:RnPn6D1AAyccwR5T+py4G3eMhZuqr0/pGM6Ygpu1tDc=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
 launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=

--- a/iam_role_test.go
+++ b/iam_role_test.go
@@ -3,7 +3,7 @@ package alks
 import (
 	"encoding/json"
 
-	. "github.com/motain/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *S) Test_CreateIamRole(c *C) {

--- a/iam_sessions_test.go
+++ b/iam_sessions_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Cox-Automotive/alks-go/testutils"
 	"testing"
 
-	. "github.com/motain/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) {

--- a/iam_user_test.go
+++ b/iam_user_test.go
@@ -1,7 +1,7 @@
 package alks
 
 import (
-	. "github.com/motain/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *S) Test_GetIamUsers(c *C) {

--- a/is_iam_enabled_test.go
+++ b/is_iam_enabled_test.go
@@ -1,7 +1,7 @@
 package alks
 
 import (
-	. "github.com/motain/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *S) Test_IsIamEnabledMI(c *C) {

--- a/login_role_test.go
+++ b/login_role_test.go
@@ -1,7 +1,7 @@
 package alks
 
 import (
-	. "github.com/motain/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *S) Test_GetMyLoginRole(c *C) {

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -3,7 +3,7 @@ package alks
 import (
 	"time"
 
-	. "github.com/motain/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *S) Test_CreateSession(c *C) {


### PR DESCRIPTION
# Description

This change resolves the issues caused by the dependant module `github.com/motain/gocheck` disappearing off the planet.  A little Googling seems to indicate that the above repo was originally forked from `labix.org/gocheck` which is now published as `gopkg.in/check.v1`.

Therefore, this update removes reference to the nonexistant modules `github.com/motain/gocheck` and `launchpad.net/gocheck` then adds a new dependency on `gopkg.in/check.v1` along with the needed updates to each `*_test.go` file to now import the newly dependent package.

No other changes are made here and all tests now succeed.

Resolves #65 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


# How has this been tested?

    $ go test && echo OK

